### PR TITLE
[JBTM-1488] several changes

### DIFF
--- a/rts/lra/lra-client/pom.xml
+++ b/rts/lra/lra-client/pom.xml
@@ -59,16 +59,18 @@
             <version>${version.junit}</version>
             <scope>test</scope>
         </dependency>
-        <!-- JAXRS 2 Client API implementation -->
+        <!-- JAXRS 2 Client API -->
         <dependency>
-            <groupId>org.jboss.resteasy</groupId>
-            <artifactId>resteasy-client</artifactId>
-            <version>${version.resteasy-client}</version>
+            <groupId>org.jboss.spec.javax.ws.rs</groupId>
+            <artifactId>jboss-jaxrs-api_2.0_spec</artifactId>
+            <version>${version.jaxrs.api}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <version>2.8.9</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 </project>

--- a/rts/lra/lra-client/src/main/java/org/jboss/narayana/rts/lra/client/LRAClient.java
+++ b/rts/lra/lra-client/src/main/java/org/jboss/narayana/rts/lra/client/LRAClient.java
@@ -343,10 +343,10 @@ public class LRAClient implements LRAClientAPI, Closeable {
     }
 
     @Override
-    public void joinLRA(URL lraId, Long timelimit, String compensatorUrl) throws GenericLRAException {
+    public String joinLRA(URL lraId, Long timelimit, String compensatorUrl) throws GenericLRAException {
         lraTrace(String.format("joining LRA with compensator %s", compensatorUrl), lraId);
 
-        enlistCompensator(lraId, timelimit, "",
+        return enlistCompensator(lraId, timelimit, "",
                 String.format("%s/compensate", compensatorUrl),
                 String.format("%s/complete", compensatorUrl),
                 String.format("%s/leave", compensatorUrl),

--- a/rts/lra/lra-client/src/main/java/org/jboss/narayana/rts/lra/client/LRAClient.java
+++ b/rts/lra/lra-client/src/main/java/org/jboss/narayana/rts/lra/client/LRAClient.java
@@ -460,8 +460,9 @@ public class LRAClient implements LRAClientAPI, Closeable {
         Annotation resourcePathAnnotation = compensatorClass.getAnnotation(Path.class);
         String resourcePath = resourcePathAnnotation == null ? "/" : ((Path) resourcePathAnnotation).value();
 
-        String uriPrefix = String.format("%s:%s%s",
-                baseUri.getScheme(), baseUri.getSchemeSpecificPart(), resourcePath.substring(1));
+        final String uriPrefix = String.format("%s:%s%s",
+                baseUri.getScheme(), baseUri.getSchemeSpecificPart(), resourcePath.substring(1))
+                .replaceAll("/$", "");
 
         final int[] validCnt = {0};
 

--- a/rts/lra/lra-client/src/main/java/org/jboss/narayana/rts/lra/client/LRAClientAPI.java
+++ b/rts/lra/lra-client/src/main/java/org/jboss/narayana/rts/lra/client/LRAClientAPI.java
@@ -171,9 +171,12 @@ public interface LRAClientAPI {
      *                     the work that was done within the scope of the LRA.
      *                     Performing a POST on URL/complete will cause the compensator to tidy up and
      *                  it can forget this LRA.  (optional)
+     *
+     * @return a recovery URL for this enlistment
+     *
      * @throws GenericLRAException Comms error
      */
-    void joinLRA(URL lraId, Long timelimit, String body) throws GenericLRAException;
+    String joinLRA(URL lraId, Long timelimit, String body) throws GenericLRAException;
 
     /**
      * Similar to {@link LRAClientAPI#joinLRA(URL, Long, String)} but the various compensator urls
@@ -187,6 +190,9 @@ public interface LRAClientAPI {
      * @param completeUrl Performing a POST on this URL  will cause the participant to tidy up and it can forget this transaction.
      * @param leaveUrl Performing a PUT on this URL with cause the compensator to leave the LRA
      * @param statusUrl Performing a GET on this URL will return the status of the compensator {@see joinLRA}
+     *
+     * @return a recovery URL for this enlistment
+     *
      * @throws GenericLRAException
      */
     String joinLRA(URL lraId, Long timelimit, String compensateUrl, String completeUrl, String leaveUrl, String statusUrl) throws GenericLRAException;

--- a/rts/lra/lra-client/src/main/resources/META-INF/services/javax.ws.rs.client.ClientBuilder
+++ b/rts/lra/lra-client/src/main/resources/META-INF/services/javax.ws.rs.client.ClientBuilder
@@ -1,1 +1,0 @@
-org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder

--- a/rts/lra/lra-client/src/main/resources/META-INF/services/javax.ws.rs.ext.Providers
+++ b/rts/lra/lra-client/src/main/resources/META-INF/services/javax.ws.rs.ext.Providers
@@ -1,3 +1,0 @@
-org.jboss.narayana.rts.lra.filter.ClientLRAResponseFilter
-org.jboss.narayana.rts.lra.filter.ClientLRARequestFilter
-

--- a/rts/lra/lra-coordinator/src/main/java/org/jboss/narayana/rts/lra/coordinator/domain/model/LRARecord.java
+++ b/rts/lra/lra-coordinator/src/main/java/org/jboss/narayana/rts/lra/coordinator/domain/model/LRARecord.java
@@ -58,7 +58,6 @@ public class LRARecord extends AbstractRecord implements Comparable<AbstractReco
     private URL completeURI;
     private URL compensateURI;
     private URL statusURI;
-    private URL leaveURI;
     private URL forgetURI;
 
     private boolean isCompelete;
@@ -89,7 +88,6 @@ public class LRARecord extends AbstractRecord implements Comparable<AbstractReco
             } else {
                 this.compensateURI = new URL(String.format("%s/compensate", linkURI));
                 this.completeURI = new URL(String.format("%s/complete", linkURI));
-                this.leaveURI = new URL(String.format("%s/leave", linkURI));
                 this.statusURI = new URL(String.format("%s/status", linkURI));
                 this.forgetURI = new URL(String.format("%s/forget", linkURI));
             }
@@ -138,8 +136,6 @@ public class LRARecord extends AbstractRecord implements Comparable<AbstractReco
                 completeURI = new URL(uri);
             else if ("status".equals(rel))
                 statusURI = new URL(uri);
-            else if ("leave".equals(rel))
-                leaveURI = new URL(uri);
             else if ("forget".equals(rel))
                 forgetURI = new URL(uri);
 
@@ -284,7 +280,6 @@ public class LRARecord extends AbstractRecord implements Comparable<AbstractReco
                 os.packString(completeURI.toString());
                 os.packString(compensateURI.toString());
                 os.packString(statusURI.toString());
-                os.packString(leaveURI.toString());
 
                 os.packBoolean(isCompelete);
                 os.packBoolean(isCompensated);
@@ -306,7 +301,6 @@ public class LRARecord extends AbstractRecord implements Comparable<AbstractReco
                 completeURI = new URL(os.unpackString());
                 compensateURI = new URL(os.unpackString());
                 statusURI = new URL(os.unpackString());
-                leaveURI = new URL(os.unpackString());
 
                 isCompelete = os.unpackBoolean();
                 isCompensated = os.unpackBoolean();

--- a/rts/lra/lra-coordinator/src/main/java/org/jboss/narayana/rts/lra/coordinator/domain/model/LRARecord.java
+++ b/rts/lra/lra-coordinator/src/main/java/org/jboss/narayana/rts/lra/coordinator/domain/model/LRARecord.java
@@ -51,7 +51,7 @@ import java.util.concurrent.TimeUnit;
 
 import static org.jboss.narayana.rts.lra.client.LRAClient.LRA_HTTP_HEADER;
 
-public class LRARecord extends AbstractRecord implements Comparable {
+public class LRARecord extends AbstractRecord implements Comparable<AbstractRecord> {
     private URL coordinatorURI;
     private String participantPath;
 
@@ -394,8 +394,7 @@ public class LRARecord extends AbstractRecord implements Comparable {
     }
 
     @Override
-    public int compareTo(Object o) {
-        AbstractRecord other = (AbstractRecord) o;
+    public int compareTo(AbstractRecord other) {
 
         if (lessThan(other))
             return -1;

--- a/rts/lra/lra-filters/pom.xml
+++ b/rts/lra/lra-filters/pom.xml
@@ -32,5 +32,11 @@
             <version>${version.cdi-api}</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.jboss.spec.javax.ws.rs</groupId>
+            <artifactId>jboss-jaxrs-api_2.0_spec</artifactId>
+            <version>${version.jaxrs.api}</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/rts/lra/lra-filters/src/main/java/org/jboss/narayana/rts/lra/filter/ServerLRAFilter.java
+++ b/rts/lra/lra-filters/src/main/java/org/jboss/narayana/rts/lra/filter/ServerLRAFilter.java
@@ -130,16 +130,17 @@ public class ServerLRAFilter implements ContainerRequestFilter, ContainerRespons
                 containerRequestContext.setProperty(CANCEL_ON_PROP, cancel0n);
         }
 
-        if (type == null) {
-            Current.clearContext(headers);
-
-            return; // not transactional
-        }
-
         boolean enlist = true;
         boolean endAnnotation = method.isAnnotationPresent(Complete.class)
                 || method.isAnnotationPresent(Compensate.class)
                 || method.isAnnotationPresent(Leave.class);
+
+        if (type == null) {
+            if(!endAnnotation)
+                Current.clearContext(headers);
+
+            return; // not transactional
+        }
 
         if (headers.containsKey(LRA_HTTP_HEADER))
             incommingLRA = new URL(headers.getFirst(LRA_HTTP_HEADER)); // TODO filters for asynchronous JAX-RS motheods should not throw exceptions

--- a/rts/lra/pom.xml
+++ b/rts/lra/pom.xml
@@ -26,6 +26,7 @@
         <xversion.resteasy-client>3.0.14.Final</xversion.resteasy-client>
         <version.resteasy-client>3.1.3.Final</version.resteasy-client>
         <version.json.api>1.1</version.json.api>
+        <version.jaxrs.api>1.0.0.Final</version.jaxrs.api>
 
         <version.jboss-interceptors>1.0.1.Final</version.jboss-interceptors>
         <version.jaxrs-api>2.0</version.jaxrs-api>


### PR DESCRIPTION
* update of dependency of resteasy client - for being at most provided, otherwise wfly swarm dependency management fails and swarm does not start properly
* compare method enhanced with generics
* discussion if `leave` is needed to be stored at coordinator (at least it should be optional)
* fixing path creation for lra url in `LRAClient`
* LRA end methods should not expect lra annotation
* returning recovery url from lra client join calls