### PR TITLE
Cdi extension with checking LRA annotations + restructuralize testing

### DIFF
--- a/rts/lra/README.adoc
+++ b/rts/lra/README.adoc
@@ -34,7 +34,7 @@ you should see a json representation of the API. A pretty version is available v
 mvn -f lra-coordinator/pom.xml wildfly-swarm:run -DskipTests -Dswarm.http.port=8080
 ```
 
-### Start a sra.demo.service on port 8081
+### Start a lra.demo.service on port 8081
 
 ```bash
 mvn -f lra-test/pom.xml clean wildfly-swarm:run -DskipTests -Dswarm.http.port=8081 -Dlra.http.port=8080
@@ -51,7 +51,7 @@ and 8081, respectively
 mvn test -f lra-client/pom.xml -Dtest=SpecTest -DskipTests=false -Dlra.http.port=8080 -Dservice.http.port=8081
 ```
 
-The system properties *lra.http.port* and *sra.demo.service.http.port* specify the ports on which the LRA coordinator and example sra.demo.service are is listening, respectively.
+The system properties *lra.http.port* and *lra.demo.service.http.port* specify the ports on which the LRA coordinator and example lra.demo.service are is listening, respectively.
 
 ## Trip Demo
 
@@ -65,10 +65,10 @@ The system properties *lra.http.port* and *sra.demo.service.http.port* specify t
     cancel LRA 3
     close LRA 1 (results in the hotel and flight option 2 being confirmed)
 
-### Make sure the coordinator and sra.demo.service (started above) are still running
+### Make sure the coordinator and lra.demo.service (started above) are still running
 
 For simplicity the trip, hotel and flight services all listen on the same http port but
-inter sra.demo.service requests are still performed using http so running each sra.demo.service in a separate
+inter lra.demo.service requests are still performed using http so running each lra.demo.service in a separate
 JVM is an option too.
 
 Start the coordinator and services:
@@ -88,7 +88,7 @@ mvn package -f lra-test/pom.xml
 java -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005 -cp lra-test/target/classes:lra-test/target/lra-test/WEB-INF/lib/jackson-jaxrs-json-provider-2.7.4.jar:lra-test/target/lra-test/WEB-INF/lib/javax.json-1.0.3.jar:lra-test/target/lra-test/WEB-INF/lib/jackson-databind-2.7.4.jar:lra-test/target/lra-test/WEB-INF/lib/jackson-core-2.7.4.jar:lra-test/target/lra-test/WEB-INF/lib/jackson-annotations-2.7.4.jar -Dservice.http.port=8081 TripClient
 ```
 
-where the *sra.demo.service.http.port* system property specifies the port the example sra.demo.service is running on.
+where the *lra.demo.service.http.port* system property specifies the port the example lra.demo.service is running on.
 
 ### One shot bookings using curl:
 

--- a/rts/lra/lra-annotations/pom.xml
+++ b/rts/lra/lra-annotations/pom.xml
@@ -9,7 +9,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.jboss.narayana.rts</groupId>
-        <artifactId>rest-lra-parent</artifactId>
+        <artifactId>lra-parent</artifactId>
         <version>5.6.0.Final-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>

--- a/rts/lra/lra-annotations/src/main/java/org/jboss/narayana/rts/lra/annotation/Compensate.java
+++ b/rts/lra/lra-annotations/src/main/java/org/jboss/narayana/rts/lra/annotation/Compensate.java
@@ -29,12 +29,13 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
+ * <p>
  * When a bean method executes in the context of an LRA any methods in the bean class that are annotated with @Compensate
  * will be used as a compensator for that LRA and when it is present, so too must the {@link Compensate} and
  * {@link Status} annotations. If it is applied to multiple methods an arbitrary one is chosen.
- *
+ * <p>
  * If the associated LRA is subsequently cancelled the method annotated with @Compensate will be invoked.
- *
+ * <p>
  * The annotation can be combined with {@link TimeLimit} annotation to limit the time that the compensator remains
  * valid, after which the corresponding @Compensate method will be called.
  */

--- a/rts/lra/lra-annotations/src/main/java/org/jboss/narayana/rts/lra/annotation/CompensatorStatus.java
+++ b/rts/lra/lra-annotations/src/main/java/org/jboss/narayana/rts/lra/annotation/CompensatorStatus.java
@@ -6,11 +6,29 @@ package org.jboss.narayana.rts.lra.annotation;
  * the {@link Status} annotation.
  */
 public enum CompensatorStatus {
-    Compensating, // the Compensator is currently compensating for the LRA.
-    Compensated, //  the Compensator has successfully compensated for the LRA.
-    FailedToCompensate, //  the Compensator was not able to compensate for the LRA (and must remember
-                        // it could not compensate until such time that it receives a forget message).
-    Completing, //  the Compensator is tidying up after being told to complete.
-    Completed, //  the Compensator has confirmed.
-    FailedToComplete, //  the Compensator was unable to tidy-up.
+    /**
+     * the Compensator is currently compensating for the LRA
+     */
+    Compensating,
+    /**
+     * the Compensator has successfully compensated for the LRA
+     */
+    Compensated,
+    /**
+     * the Compensator was not able to compensate for the LRA (and must remember
+     * it could not compensate until such time that it receives a forget message)
+     */
+    FailedToCompensate,
+    /**
+     * the Compensator is tidying up after being told to complete
+     */
+    Completing,
+    /**
+     * the Compensator has confirmed
+     */
+    Completed,
+    /**
+     * the Compensator was unable to tidy-up
+     */
+    FailedToComplete,
 }

--- a/rts/lra/lra-annotations/src/main/java/org/jboss/narayana/rts/lra/annotation/Complete.java
+++ b/rts/lra/lra-annotations/src/main/java/org/jboss/narayana/rts/lra/annotation/Complete.java
@@ -29,12 +29,13 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
+ * <p>
  * When a bean method executes in the context of an LRA any methods in the bean class that are annotated with @Complete
  * will be used as a compensator for that LRA and when it is present, so too must the {@link Compensate} and
  * {@link Status} annotations. If it is applied to multiple methods an arbitrary one is chosen.
- *
+ * <p>
  * If the associated LRA is subsequently closed the method annotated with @Complete will be invoked.
- *
+ * <p>
  * The annotation can be combined with {@link TimeLimit} annotation to limit the time that the compensator
  * remains valid, after which the corresponding @Compensate method will be called.
  */

--- a/rts/lra/lra-annotations/src/main/java/org/jboss/narayana/rts/lra/annotation/LRA.java
+++ b/rts/lra/lra-annotations/src/main/java/org/jboss/narayana/rts/lra/annotation/LRA.java
@@ -77,8 +77,8 @@ public @interface LRA {
         REQUIRES_NEW,
 
         /**
-         *  <p>If called outside a transaction context, the method call will return with a 412 Precondition Failed
-         *  HTTP status code</p>
+         *  <p>If called outside a transaction context, the method call will return
+         *  with a 412 Precondition Failed HTTP status code</p>
          *  <p>If called inside a transaction context the bean method execution will then continue under that context.</p>
          */
         MANDATORY,
@@ -100,7 +100,7 @@ public @interface LRA {
         /**
          *  <p>If called outside a LRA context, managed bean method execution
          *  must then continue outside a LRA context.</p>
-         *  <p>If called inside a LRA context the method is not executed and a 412 Precondition Failed HTTP status code
+         *  <p>If called inside a LRA context the method is not executed and a <code>412 Precondition Failed</code> HTTP status code
          *  is returned to the caller.</p>
          */
         NEVER

--- a/rts/lra/lra-annotations/src/main/java/org/jboss/narayana/rts/lra/annotation/NestedLRA.java
+++ b/rts/lra/lra-annotations/src/main/java/org/jboss/narayana/rts/lra/annotation/NestedLRA.java
@@ -29,38 +29,36 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
+ * <p>
  * Used on the interface or class. Defines that the container will create
  * a new LRA for each method invocation, regardless of whether or not there is
  * already an LRA associated with the caller. These LRAs will then
  * either be top-level LRAs or nested automatically depending upon the
  * context within which they are created.
- *
+ * <p>
  * When a nested LRA is closed its' compensators are completed but retained. At any time prior to the enclosing LRA
  * being closed or cancelled the nested LRA can be told to compensate (even though it may have already been told
  * to complete).
- *
- * Compatability with the @LRA annotation: if @LRA is not present @Nested is ignored, otherwise the behaviour depends
- * upon the value of the Type attribute:
- *
- * REQUIRED
- *  if there is an LRA present a new LRA is nested under it
- *
- * REQUIRES_NEW,
- *  the @Nested annotation is ignored
- *
- * MANDATORY,
- *  a new LRA is nested under the incoming LRA
- *
- * SUPPORTS,
- *  if there is an LRA present a new LRA is nested under otherwise a new top level LRA is begun
- *
- * NOT_SUPPORTED,
- *  nested does not make sense and operations on this resource that contain a LRA context will immediately return
- *  with a 412 Precondition Failed HTTP status code
- *
- * NEVER
- *  nested does not make sense and requests that carry a LRA context will immediately return
- *  with a 412 Precondition Failed HTTP status code
+ * <p>
+ * Compatability with the @LRA annotation: if {@link LRA} is not present @NestedLRA is ignored, otherwise the behaviour depends
+ * upon the value of the @LRA type attribute:
+ * <p>
+ * <ul>
+ *   <li>REQUIRED
+ *     if there is an LRA present a new LRA is nested under it
+ *   <li>REQUIRES_NEW,
+ *     the @NestedLRA annotation is ignored
+ *  <li>MANDATORY,
+ *     a new LRA is nested under the incoming LRA
+ *  <li>SUPPORTS,
+ *    if there is an LRA present a new LRA is nested under otherwise a new top level LRA is begun
+ *  <li>NOT_SUPPORTED,
+ *    nested does not make sense and operations on this resource that contain a LRA context will immediately return
+ *    with a <code>412 Precondition Failed</code> HTTP status code
+ *  <li>NEVER,
+ *    nested does not make sense and requests that carry a LRA context will immediately return
+ *    with a <code>412 Precondition Failed</code> HTTP status code
+ * </ul>
  */
 @Inherited
 @InterceptorBinding

--- a/rts/lra/lra-annotations/src/main/java/org/jboss/narayana/rts/lra/annotation/Status.java
+++ b/rts/lra/lra-annotations/src/main/java/org/jboss/narayana/rts/lra/annotation/Status.java
@@ -28,14 +28,15 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
+ * <p>
  * In order to support recovery compensators must be able to report their status once the completion part of the protocol
  * starts.
- *
+ * <p>
  * Methods annotated with this annotation must be JAX-RS resources and respond to GET requests (ie are annotated with
- * @Path and @GET, respectively). They must report their status using one of the enum names listed
+ * javax.ws.rs.Path and javax.ws.rs.GET, respectively). They must report their status using one of the enum names listed
  * in {@link CompensatorStatus} whenever an HTTP GET request is made on the method.
- *
- * If the compensator has not yet been asked to complete or compensate it should return with a 412 Precondition Failed
+ * <p>
+ * If the compensator has not yet been asked to complete or compensate it should return with a <code>412 Precondition Failed</code>
  * HTTP status code. NB although this circumstance could be detected via the framework
  * it would necessitate a network call to the LRA coordinator.
  */

--- a/rts/lra/lra-annotations/src/main/java/org/jboss/narayana/rts/lra/annotation/TimeLimit.java
+++ b/rts/lra/lra-annotations/src/main/java/org/jboss/narayana/rts/lra/annotation/TimeLimit.java
@@ -30,9 +30,10 @@ import java.lang.annotation.Target;
 import java.util.concurrent.TimeUnit;
 
 /**
+ * <p>
  * Used on ({@link LRA} and {@link Compensate} annotations to indicate the maximum time that the LRA or
  * compensator should remain active for.
- *
+ * <p>
  * When applied at the class level the timeout applies to any method that starts an LRA or registers a compensator.
  */
 @InterceptorBinding
@@ -41,7 +42,7 @@ import java.util.concurrent.TimeUnit;
 public @interface TimeLimit {
     /**
      * @return the period for which the LRA or compensator will remain valid. A value
-     * of zero indicates that it is always remain valid.
+     * of zero indicates that it is always remain valid.<br>
      *
      * For compensations the corresponding compensation (a method annotated with {@link Compensate} in the
      * same class) will be invoked if the time limit is reached.

--- a/rts/lra/lra-cdi-rest/README.adoc
+++ b/rts/lra/lra-cdi-rest/README.adoc
@@ -1,0 +1,20 @@
+## What is the purpose of the module
+
+This module serves as a simple checker of prerequisites that usage of `@LRA` mandates.
+As example we can say that class annotated with `@LRA` is expected to contains annotations
+`@Status`, `@Compensate` and `@Complete`. All of this method needs to define `@Path` annotation etc.
+
+### Usage
+
+Only add the dependency to this project to your project. Then during the container startup
+(the term container here invoves e.g. instance of WildFly Swarm too) there is loaded
+a CDI extension which throws `DeploymentException` with description of the issue.
+
+The coordinates of this artifact are
+
+```
+<dependency>
+  <groupId>org.jboss.narayana.rts</groupId>
+  <artifactId>lra-cdi-rest</artifactId>
+</dependency>
+```

--- a/rts/lra/lra-cdi-rest/foobar.log
+++ b/rts/lra/lra-cdi-rest/foobar.log
@@ -1,0 +1,255 @@
+22:08:15,047 WARN  [org.jboss.as.txn] (ServerService Thread Pool -- 15) WFLYTX0013: Node identifier property is set to the default value. Please make sure it is unique.
+22:08:15,059 INFO  [org.jboss.as.security] (ServerService Thread Pool -- 18) WFLYSEC0002: Activating Security Subsystem
+22:08:15,063 INFO  [org.jboss.as.naming] (ServerService Thread Pool -- 21) WFLYNAM0001: Activating Naming Subsystem
+22:08:15,083 INFO  [org.wildfly.extension.undertow] (MSC service thread 1-1) WFLYUT0003: Undertow 1.4.11.Final starting
+22:08:15,085 INFO  [org.wildfly.extension.io] (ServerService Thread Pool -- 13) WFLYIO001: Worker 'default' has auto-configured to 8 core threads with 64 task threads based on your 4 available processors
+22:08:15,085 INFO  [org.jboss.as.security] (MSC service thread 1-3) WFLYSEC0001: Current PicketBox version=4.9.6.Final
+22:08:15,158 INFO  [org.jboss.as.naming] (MSC service thread 1-6) WFLYNAM0003: Starting Naming Service
+22:08:15,214 INFO  [org.xnio] (MSC service thread 1-4) XNIO version 3.4.3.Final
+22:08:15,256 INFO  [org.xnio.nio] (MSC service thread 1-4) XNIO NIO Implementation Version 3.4.3.Final
+22:08:15,368 INFO  [org.wildfly.extension.undertow] (MSC service thread 1-4) WFLYUT0012: Started server default-server.
+22:08:15,450 INFO  [org.wildfly.extension.undertow] (MSC service thread 1-4) WFLYUT0006: Undertow HTTP listener default listening on [0:0:0:0:0:0:0:0]:8080
+22:08:15,541 INFO  [org.jboss.as] (Controller Boot Thread) WFLYSRV0025: WildFly Swarm 2017.8.1 (WildFly Core 2.2.1.Final) started in 1645ms - Started 88 of 97 services (18 services are lazy, passive or on-demand)
+22:08:16,608 INFO  [org.wildfly.swarm.runtime.deployer] (main) deploying lra-cdi-check.war
+22:08:16,648 INFO  [org.jboss.as.server.deployment] (MSC service thread 1-2) WFLYSRV0027: Starting deployment of "lra-cdi-check.war" (runtime-name: "lra-cdi-check.war")
+22:08:16,854 WARN  [org.jboss.as.dependency.private] (MSC service thread 1-4) WFLYSRV0018: Deployment "deployment.lra-cdi-check.war" is using a private module ("org.jboss.jts:main") which may be changed or removed in future versions without notice.
+22:08:16,922 INFO  [org.jboss.weld.deployer] (MSC service thread 1-3) WFLYWELD0003: Processing weld deployment lra-cdi-check.war
+22:08:17,141 INFO  [org.hibernate.validator.internal.util.Version] (MSC service thread 1-3) HV000001: Hibernate Validator 5.2.4.Final
+22:08:17,287 INFO  [org.jboss.weld.Version] (MSC service thread 1-3) WELD-000900: 2.3.5 (Final)
+22:08:17,315 INFO  [org.wildfly.extension.undertow] (MSC service thread 1-8) WFLYUT0018: Host default-host starting
+22:08:17,551 ERROR [org.jboss.msc.service.fail] (MSC service thread 1-1) MSC000001: Failed to start service jboss.deployment.unit."lra-cdi-check.war".WeldStartService: org.jboss.msc.service.StartException in service jboss.deployment.unit."lra-cdi-check.war".WeldStartService: Failed to start service
+	at org.jboss.msc.service.ServiceControllerImpl$StartTask.run(ServiceControllerImpl.java:1904)
+	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
+	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
+	at java.lang.Thread.run(Thread.java:745)
+Caused by: org.jboss.weld.exceptions.DefinitionException: Exception List with 1 exceptions:
+Exception 0 :
+java.lang.IndexOutOfBoundsException: Index: 0, Size: 0
+	at java.util.ArrayList.rangeCheck(ArrayList.java:653)
+	at java.util.ArrayList.get(ArrayList.java:429)
+	at org.jboss.narayana.rts.lra.cdi.LraAnnotationProcessingExtension.processLraAnnotatedType(LraAnnotationProcessingExtension.java:162)
+	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
+	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
+	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
+	at java.lang.reflect.Method.invoke(Method.java:498)
+	at org.jboss.weld.injection.StaticMethodInjectionPoint.invoke(StaticMethodInjectionPoint.java:88)
+	at org.jboss.weld.injection.StaticMethodInjectionPoint.invoke(StaticMethodInjectionPoint.java:78)
+	at org.jboss.weld.injection.MethodInvocationStrategy$SimpleMethodInvocationStrategy.invoke(MethodInvocationStrategy.java:129)
+	at org.jboss.weld.event.ObserverMethodImpl.sendEvent(ObserverMethodImpl.java:313)
+	at org.jboss.weld.event.ExtensionObserverMethodImpl.sendEvent(ExtensionObserverMethodImpl.java:125)
+	at org.jboss.weld.event.ObserverMethodImpl.sendEvent(ObserverMethodImpl.java:291)
+	at org.jboss.weld.event.ObserverMethodImpl.notify(ObserverMethodImpl.java:269)
+	at org.jboss.weld.bootstrap.events.ContainerLifecycleEvents.fireProcessAnnotatedType(ContainerLifecycleEvents.java:197)
+	at org.jboss.weld.bootstrap.events.ContainerLifecycleEvents.fireProcessAnnotatedType(ContainerLifecycleEvents.java:169)
+	at org.jboss.weld.bootstrap.BeanDeployer.processAnnotatedTypes(BeanDeployer.java:159)
+	at org.jboss.weld.bootstrap.BeanDeployment.createTypes(BeanDeployment.java:224)
+	at org.jboss.weld.bootstrap.WeldStartup.startInitialization(WeldStartup.java:383)
+	at org.jboss.weld.bootstrap.WeldBootstrap.startInitialization(WeldBootstrap.java:76)
+	at org.jboss.as.weld.WeldStartService.start(WeldStartService.java:94)
+	at org.jboss.msc.service.ServiceControllerImpl$StartTask.startService(ServiceControllerImpl.java:1948)
+	at org.jboss.msc.service.ServiceControllerImpl$StartTask.run(ServiceControllerImpl.java:1881)
+	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
+	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
+	at java.lang.Thread.run(Thread.java:745)
+
+	at org.jboss.weld.bootstrap.events.ContainerLifecycleEvents.fireProcessAnnotatedType(ContainerLifecycleEvents.java:204)
+	at org.jboss.weld.bootstrap.events.ContainerLifecycleEvents.fireProcessAnnotatedType(ContainerLifecycleEvents.java:169)
+	at org.jboss.weld.bootstrap.BeanDeployer.processAnnotatedTypes(BeanDeployer.java:159)
+	at org.jboss.weld.bootstrap.BeanDeployment.createTypes(BeanDeployment.java:224)
+	at org.jboss.weld.bootstrap.WeldStartup.startInitialization(WeldStartup.java:383)
+	at org.jboss.weld.bootstrap.WeldBootstrap.startInitialization(WeldBootstrap.java:76)
+	at org.jboss.as.weld.WeldStartService.start(WeldStartService.java:94)
+	at org.jboss.msc.service.ServiceControllerImpl$StartTask.startService(ServiceControllerImpl.java:1948)
+	at org.jboss.msc.service.ServiceControllerImpl$StartTask.run(ServiceControllerImpl.java:1881)
+	... 3 more
+
+22:08:17,555 ERROR [org.jboss.as.controller.management-operation] (main) WFLYCTL0013: Operation ("add") failed - address: (("deployment" => "lra-cdi-check.war")) - failure description: {
+    "WFLYCTL0080: Failed services" => {"jboss.deployment.unit.\"lra-cdi-check.war\".WeldStartService" => "org.jboss.msc.service.StartException in service jboss.deployment.unit.\"lra-cdi-check.war\".WeldStartService: Failed to start service
+    Caused by: org.jboss.weld.exceptions.DefinitionException: Exception List with 1 exceptions:
+Exception 0 :
+java.lang.IndexOutOfBoundsException: Index: 0, Size: 0
+	at java.util.ArrayList.rangeCheck(ArrayList.java:653)
+	at java.util.ArrayList.get(ArrayList.java:429)
+	at org.jboss.narayana.rts.lra.cdi.LraAnnotationProcessingExtension.processLraAnnotatedType(LraAnnotationProcessingExtension.java:162)
+	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
+	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
+	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
+	at java.lang.reflect.Method.invoke(Method.java:498)
+	at org.jboss.weld.injection.StaticMethodInjectionPoint.invoke(StaticMethodInjectionPoint.java:88)
+	at org.jboss.weld.injection.StaticMethodInjectionPoint.invoke(StaticMethodInjectionPoint.java:78)
+	at org.jboss.weld.injection.MethodInvocationStrategy$SimpleMethodInvocationStrategy.invoke(MethodInvocationStrategy.java:129)
+	at org.jboss.weld.event.ObserverMethodImpl.sendEvent(ObserverMethodImpl.java:313)
+	at org.jboss.weld.event.ExtensionObserverMethodImpl.sendEvent(ExtensionObserverMethodImpl.java:125)
+	at org.jboss.weld.event.ObserverMethodImpl.sendEvent(ObserverMethodImpl.java:291)
+	at org.jboss.weld.event.ObserverMethodImpl.notify(ObserverMethodImpl.java:269)
+	at org.jboss.weld.bootstrap.events.ContainerLifecycleEvents.fireProcessAnnotatedType(ContainerLifecycleEvents.java:197)
+	at org.jboss.weld.bootstrap.events.ContainerLifecycleEvents.fireProcessAnnotatedType(ContainerLifecycleEvents.java:169)
+	at org.jboss.weld.bootstrap.BeanDeployer.processAnnotatedTypes(BeanDeployer.java:159)
+	at org.jboss.weld.bootstrap.BeanDeployment.createTypes(BeanDeployment.java:224)
+	at org.jboss.weld.bootstrap.WeldStartup.startInitialization(WeldStartup.java:383)
+	at org.jboss.weld.bootstrap.WeldBootstrap.startInitialization(WeldBootstrap.java:76)
+	at org.jboss.as.weld.WeldStartService.start(WeldStartService.java:94)
+	at org.jboss.msc.service.ServiceControllerImpl$StartTask.startService(ServiceControllerImpl.java:1948)
+	at org.jboss.msc.service.ServiceControllerImpl$StartTask.run(ServiceControllerImpl.java:1881)
+	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
+	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
+	at java.lang.Thread.run(Thread.java:745)
+"},
+    "WFLYCTL0412: Required services that are not installed:" => ["jboss.deployment.unit.\"lra-cdi-check.war\".WeldStartService"],
+    "WFLYCTL0180: Services with missing/unavailable dependencies" => undefined
+}
+22:08:17,563 ERROR [org.jboss.as.server] (main) WFLYSRV0021: Deploy of deployment "lra-cdi-check.war" was rolled back with the following failure message: 
+{
+    "WFLYCTL0080: Failed services" => {"jboss.deployment.unit.\"lra-cdi-check.war\".WeldStartService" => "org.jboss.msc.service.StartException in service jboss.deployment.unit.\"lra-cdi-check.war\".WeldStartService: Failed to start service
+    Caused by: org.jboss.weld.exceptions.DefinitionException: Exception List with 1 exceptions:
+Exception 0 :
+java.lang.IndexOutOfBoundsException: Index: 0, Size: 0
+	at java.util.ArrayList.rangeCheck(ArrayList.java:653)
+	at java.util.ArrayList.get(ArrayList.java:429)
+	at org.jboss.narayana.rts.lra.cdi.LraAnnotationProcessingExtension.processLraAnnotatedType(LraAnnotationProcessingExtension.java:162)
+	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
+	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
+	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
+	at java.lang.reflect.Method.invoke(Method.java:498)
+	at org.jboss.weld.injection.StaticMethodInjectionPoint.invoke(StaticMethodInjectionPoint.java:88)
+	at org.jboss.weld.injection.StaticMethodInjectionPoint.invoke(StaticMethodInjectionPoint.java:78)
+	at org.jboss.weld.injection.MethodInvocationStrategy$SimpleMethodInvocationStrategy.invoke(MethodInvocationStrategy.java:129)
+	at org.jboss.weld.event.ObserverMethodImpl.sendEvent(ObserverMethodImpl.java:313)
+	at org.jboss.weld.event.ExtensionObserverMethodImpl.sendEvent(ExtensionObserverMethodImpl.java:125)
+	at org.jboss.weld.event.ObserverMethodImpl.sendEvent(ObserverMethodImpl.java:291)
+	at org.jboss.weld.event.ObserverMethodImpl.notify(ObserverMethodImpl.java:269)
+	at org.jboss.weld.bootstrap.events.ContainerLifecycleEvents.fireProcessAnnotatedType(ContainerLifecycleEvents.java:197)
+	at org.jboss.weld.bootstrap.events.ContainerLifecycleEvents.fireProcessAnnotatedType(ContainerLifecycleEvents.java:169)
+	at org.jboss.weld.bootstrap.BeanDeployer.processAnnotatedTypes(BeanDeployer.java:159)
+	at org.jboss.weld.bootstrap.BeanDeployment.createTypes(BeanDeployment.java:224)
+	at org.jboss.weld.bootstrap.WeldStartup.startInitialization(WeldStartup.java:383)
+	at org.jboss.weld.bootstrap.WeldBootstrap.startInitialization(WeldBootstrap.java:76)
+	at org.jboss.as.weld.WeldStartService.start(WeldStartService.java:94)
+	at org.jboss.msc.service.ServiceControllerImpl$StartTask.startService(ServiceControllerImpl.java:1948)
+	at org.jboss.msc.service.ServiceControllerImpl$StartTask.run(ServiceControllerImpl.java:1881)
+	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
+	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
+	at java.lang.Thread.run(Thread.java:745)
+"},
+    "WFLYCTL0412: Required services that are not installed:" => ["jboss.deployment.unit.\"lra-cdi-check.war\".WeldStartService"],
+    "WFLYCTL0180: Services with missing/unavailable dependencies" => undefined
+}
+22:08:17,594 INFO  [org.wildfly.extension.undertow] (MSC service thread 1-7) WFLYUT0019: Host default-host stopping
+22:08:17,599 INFO  [org.jboss.as.server.deployment] (MSC service thread 1-1) WFLYSRV0028: Stopped deployment lra-cdi-check.war (runtime-name: lra-cdi-check.war) in 41ms
+22:08:17,602 INFO  [org.jboss.as.controller] (main) WFLYCTL0183: Service status report
+WFLYCTL0184:    New missing/unsatisfied dependencies:
+      service jboss.deployment.unit."lra-cdi-check.war".WeldBootstrapService (missing) dependents: [service jboss.deployment.unit."lra-cdi-check.war".component."org.jboss.weld.servlet.WeldTerminalListener".WeldInstantiator, service jboss.deployment.unit."lra-cdi-check.war".CdiValidatorFactoryService, service jboss.deployment.unit."lra-cdi-check.war".component."org.jboss.weld.servlet.WeldInitialListener".WeldInstantiator, service jboss.deployment.unit."lra-cdi-check.war".component."javax.servlet.jsp.jstl.tlv.ScriptFreeTLV".WeldInstantiator, WFLYCTL0208: ... and 2 more ] 
+      service jboss.deployment.unit."lra-cdi-check.war".WeldStartService (missing) dependents: [service jboss.deployment.unit."lra-cdi-check.war".component."org.jboss.weld.servlet.WeldTerminalListener".WeldInstantiator, service jboss.undertow.deployment.default-server.default-host./, service jboss.deployment.unit."lra-cdi-check.war".CdiValidatorFactoryService, service jboss.undertow.deployment.default-server.default-host./.UndertowDeploymentInfoService, WFLYCTL0208: ... and 4 more ] 
+      service jboss.deployment.unit."lra-cdi-check.war".component."javax.servlet.jsp.jstl.tlv.PermittedTaglibsTLV".CREATE (missing) dependents: [service jboss.deployment.unit."lra-cdi-check.war".component."javax.servlet.jsp.jstl.tlv.PermittedTaglibsTLV".START] 
+      service jboss.deployment.unit."lra-cdi-check.war".component."javax.servlet.jsp.jstl.tlv.PermittedTaglibsTLV".START (missing) dependents: [service jboss.undertow.deployment.default-server.default-host./, service jboss.undertow.deployment.default-server.default-host./.UndertowDeploymentInfoService, service jboss.deployment.unit."lra-cdi-check.war".deploymentCompleteService] 
+      service jboss.deployment.unit."lra-cdi-check.war".component."javax.servlet.jsp.jstl.tlv.PermittedTaglibsTLV".WeldInstantiator (missing) dependents: [service jboss.deployment.unit."lra-cdi-check.war".component."javax.servlet.jsp.jstl.tlv.PermittedTaglibsTLV".START] 
+      service jboss.deployment.unit."lra-cdi-check.war".component."javax.servlet.jsp.jstl.tlv.ScriptFreeTLV".CREATE (missing) dependents: [service jboss.deployment.unit."lra-cdi-check.war".component."javax.servlet.jsp.jstl.tlv.ScriptFreeTLV".START] 
+      service jboss.deployment.unit."lra-cdi-check.war".component."javax.servlet.jsp.jstl.tlv.ScriptFreeTLV".START (missing) dependents: [service jboss.undertow.deployment.default-server.default-host./, service jboss.undertow.deployment.default-server.default-host./.UndertowDeploymentInfoService, service jboss.deployment.unit."lra-cdi-check.war".deploymentCompleteService] 
+      service jboss.deployment.unit."lra-cdi-check.war".component."javax.servlet.jsp.jstl.tlv.ScriptFreeTLV".WeldInstantiator (missing) dependents: [service jboss.deployment.unit."lra-cdi-check.war".component."javax.servlet.jsp.jstl.tlv.ScriptFreeTLV".START] 
+      service jboss.deployment.unit."lra-cdi-check.war".component."org.jboss.weld.servlet.WeldInitialListener".CREATE (missing) dependents: [service jboss.deployment.unit."lra-cdi-check.war".component."org.jboss.weld.servlet.WeldInitialListener".START] 
+      service jboss.deployment.unit."lra-cdi-check.war".component."org.jboss.weld.servlet.WeldInitialListener".START (missing) dependents: [service jboss.undertow.deployment.default-server.default-host./, service jboss.undertow.deployment.default-server.default-host./.UndertowDeploymentInfoService, service jboss.deployment.unit."lra-cdi-check.war".deploymentCompleteService] 
+      service jboss.deployment.unit."lra-cdi-check.war".component."org.jboss.weld.servlet.WeldInitialListener".WeldInstantiator (missing) dependents: [service jboss.deployment.unit."lra-cdi-check.war".component."org.jboss.weld.servlet.WeldInitialListener".START] 
+      service jboss.deployment.unit."lra-cdi-check.war".component."org.jboss.weld.servlet.WeldTerminalListener".CREATE (missing) dependents: [service jboss.deployment.unit."lra-cdi-check.war".component."org.jboss.weld.servlet.WeldTerminalListener".START] 
+      service jboss.deployment.unit."lra-cdi-check.war".component."org.jboss.weld.servlet.WeldTerminalListener".START (missing) dependents: [service jboss.undertow.deployment.default-server.default-host./, service jboss.undertow.deployment.default-server.default-host./.UndertowDeploymentInfoService, service jboss.deployment.unit."lra-cdi-check.war".deploymentCompleteService] 
+      service jboss.deployment.unit."lra-cdi-check.war".component."org.jboss.weld.servlet.WeldTerminalListener".WeldInstantiator (missing) dependents: [service jboss.deployment.unit."lra-cdi-check.war".component."org.jboss.weld.servlet.WeldTerminalListener".START] 
+      service jboss.deployment.unit."lra-cdi-check.war".ee.ComponentRegistry (missing) dependents: [service jboss.undertow.deployment.default-server.default-host./.UndertowDeploymentInfoService] 
+      service jboss.deployment.unit."lra-cdi-check.war".jndiDependencyService (missing) dependents: [service jboss.deployment.unit."lra-cdi-check.war".component."org.jboss.weld.servlet.WeldInitialListener".START, service jboss.deployment.unit."lra-cdi-check.war".component."org.jboss.weld.servlet.WeldTerminalListener".START, service jboss.deployment.unit."lra-cdi-check.war".component."javax.servlet.jsp.jstl.tlv.PermittedTaglibsTLV".START, service jboss.deployment.unit."lra-cdi-check.war".component."javax.servlet.jsp.jstl.tlv.ScriptFreeTLV".START] 
+      service jboss.undertow.deployment.default-server.default-host./ (missing) dependents: [service jboss.deployment.unit."lra-cdi-check.war".deploymentCompleteService] 
+      service jboss.undertow.deployment.default-server.default-host./.UndertowDeploymentInfoService (missing) dependents: [service jboss.undertow.deployment.default-server.default-host./] 
+      service jboss.undertow.deployment.default-server.default-host./.codec (missing) dependents: [service jboss.undertow.deployment.default-server.default-host./.UndertowDeploymentInfoService] 
+      service jboss.undertow.deployment.default-server.default-host./.session (missing) dependents: [service jboss.undertow.deployment.default-server.default-host./.UndertowDeploymentInfoService] 
+      service org.wildfly.request-controller.control-point."lra-cdi-check.war".undertow (missing) dependents: [service jboss.undertow.deployment.default-server.default-host./.UndertowDeploymentInfoService] 
+WFLYCTL0186:   Services which failed to start:      service jboss.deployment.unit."lra-cdi-check.war".WeldStartService
+
+22:08:17,614 INFO  [org.wildfly.extension.undertow] (MSC service thread 1-6) WFLYUT0008: Undertow HTTP listener default suspending
+22:08:17,634 INFO  [org.wildfly.extension.undertow] (MSC service thread 1-6) WFLYUT0007: Undertow HTTP listener default stopped, was bound to [0:0:0:0:0:0:0:0]:8080
+22:08:17,637 INFO  [org.wildfly.extension.undertow] (MSC service thread 1-8) WFLYUT0004: Undertow 1.4.11.Final stopping
+22:08:17,655 INFO  [org.jboss.as] (MSC service thread 1-7) WFLYSRV0050: WildFly Swarm 2017.8.1 (WildFly Core 2.2.1.Final) stopped in 20ms
+22:08:17,679 INFO  [org.jboss.weld.Bootstrap] (main) WELD-ENV-002001: Weld SE container internal shut down
+22:08:17,729 INFO  [org.wildfly.swarm] (main) WFSWARM0013: Installed fraction:                  Logging - STABLE          org.wildfly.swarm:logging:2017.8.1
+22:08:17,730 INFO  [org.wildfly.swarm] (main) WFSWARM0013: Installed fraction:          Bean Validation - STABLE          org.wildfly.swarm:bean-validation:2017.8.1
+22:08:17,730 INFO  [org.wildfly.swarm] (main) WFSWARM0013: Installed fraction:        CDI Configuration - STABLE          org.wildfly.swarm:cdi-config:2017.8.1
+22:08:17,730 INFO  [org.wildfly.swarm] (main) WFSWARM0013: Installed fraction:             Transactions - STABLE          org.wildfly.swarm:transactions:2017.8.1
+22:08:17,730 INFO  [org.wildfly.swarm] (main) WFSWARM0013: Installed fraction:                      CDI - STABLE          org.wildfly.swarm:cdi:2017.8.1
+22:08:17,730 INFO  [org.wildfly.swarm] (main) WFSWARM0013: Installed fraction:                 Undertow - STABLE          org.wildfly.swarm:undertow:2017.8.1
+22:08:17,730 INFO  [org.wildfly.swarm] (main) WFSWARM0013: Installed fraction:                   JAX-RS - STABLE          org.wildfly.swarm:jaxrs:2017.8.1
+22:08:18,092 INFO  [org.jboss.as] (MSC service thread 2-8) WFLYSRV0049: WildFly Swarm 2017.8.1 (WildFly Core 2.2.1.Final) starting
+22:08:18,099 INFO  [org.wildfly.swarm] (MSC service thread 2-8) WFSWARM0019: Install MSC service for command line args: [-Dswarm.logging.periodic-rotating-file-handlers=FILE, -Dswarm.logging.periodic-rotating-file-handlers.FILE.file.path=/tmp/junit5288995100925921595/junit8326929208500928655.tmp, -Dswarm.logging.root-logger.handlers=[CONSOLE,FILE]]
+22:09:51,432 WARN  [org.jboss.as.txn] (ServerService Thread Pool -- 16) WFLYTX0013: Node identifier property is set to the default value. Please make sure it is unique.
+22:09:51,464 INFO  [org.jboss.as.security] (ServerService Thread Pool -- 19) WFLYSEC0002: Activating Security Subsystem
+22:09:51,477 INFO  [org.jboss.as.naming] (ServerService Thread Pool -- 21) WFLYNAM0001: Activating Naming Subsystem
+22:09:51,496 INFO  [org.wildfly.extension.io] (ServerService Thread Pool -- 15) WFLYIO001: Worker 'default' has auto-configured to 8 core threads with 64 task threads based on your 4 available processors
+22:09:51,502 INFO  [org.wildfly.extension.undertow] (MSC service thread 1-7) WFLYUT0003: Undertow 1.4.11.Final starting
+22:09:51,530 INFO  [org.jboss.as.security] (MSC service thread 1-8) WFLYSEC0001: Current PicketBox version=4.9.6.Final
+22:09:51,580 INFO  [org.jboss.as.naming] (MSC service thread 1-2) WFLYNAM0003: Starting Naming Service
+22:09:51,644 INFO  [org.xnio] (MSC service thread 1-7) XNIO version 3.4.3.Final
+22:09:51,686 INFO  [org.xnio.nio] (MSC service thread 1-7) XNIO NIO Implementation Version 3.4.3.Final
+22:09:51,908 INFO  [org.wildfly.extension.undertow] (MSC service thread 1-4) WFLYUT0012: Started server default-server.
+22:09:52,021 INFO  [org.wildfly.extension.undertow] (MSC service thread 1-4) WFLYUT0006: Undertow HTTP listener default listening on [0:0:0:0:0:0:0:0]:8080
+22:09:52,255 INFO  [org.jboss.as] (Controller Boot Thread) WFLYSRV0025: WildFly Swarm 2017.8.1 (WildFly Core 2.2.1.Final) started in 2142ms - Started 88 of 97 services (18 services are lazy, passive or on-demand)
+22:09:53,633 INFO  [org.wildfly.swarm.runtime.deployer] (main) deploying lra-cdi-check.war
+22:09:53,657 INFO  [org.jboss.as.server.deployment] (MSC service thread 1-3) WFLYSRV0027: Starting deployment of "lra-cdi-check.war" (runtime-name: "lra-cdi-check.war")
+22:09:53,852 WARN  [org.jboss.as.dependency.private] (MSC service thread 1-7) WFLYSRV0018: Deployment "deployment.lra-cdi-check.war" is using a private module ("org.jboss.jts:main") which may be changed or removed in future versions without notice.
+22:09:53,895 INFO  [org.jboss.weld.deployer] (MSC service thread 1-5) WFLYWELD0003: Processing weld deployment lra-cdi-check.war
+22:09:54,110 INFO  [org.hibernate.validator.internal.util.Version] (MSC service thread 1-5) HV000001: Hibernate Validator 5.2.4.Final
+22:09:54,275 INFO  [org.jboss.weld.Version] (MSC service thread 1-5) WELD-000900: 2.3.5 (Final)
+22:09:54,312 INFO  [org.wildfly.extension.undertow] (MSC service thread 1-1) WFLYUT0018: Host default-host starting
+22:09:55,147 INFO  [org.jboss.resteasy.resteasy_jaxrs.i18n] (ServerService Thread Pool -- 23) RESTEASY002225: Deploying javax.ws.rs.core.Application: class org.wildfly.swarm.generated.WildFlySwarmDefaultJAXRSApplication$Proxy$_$$_WeldClientProxy
+22:09:55,156 INFO  [org.wildfly.extension.undertow] (ServerService Thread Pool -- 23) WFLYUT0021: Registered web context: /
+22:09:55,207 INFO  [org.jboss.as.server] (main) WFLYSRV0010: Deployed "lra-cdi-check.war" (runtime-name : "lra-cdi-check.war")
+22:09:55,225 INFO  [org.wildfly.extension.undertow] (MSC service thread 1-3) WFLYUT0008: Undertow HTTP listener default suspending
+22:09:55,232 INFO  [org.wildfly.extension.undertow] (ServerService Thread Pool -- 23) WFLYUT0022: Unregistered web context: /
+22:09:55,232 INFO  [org.wildfly.extension.undertow] (MSC service thread 1-3) WFLYUT0007: Undertow HTTP listener default stopped, was bound to [0:0:0:0:0:0:0:0]:8080
+22:09:55,240 INFO  [org.wildfly.extension.undertow] (MSC service thread 1-8) WFLYUT0019: Host default-host stopping
+22:09:55,241 INFO  [org.wildfly.extension.undertow] (MSC service thread 1-1) WFLYUT0004: Undertow 1.4.11.Final stopping
+22:09:55,267 INFO  [org.jboss.as.server.deployment] (MSC service thread 1-1) WFLYSRV0028: Stopped deployment lra-cdi-check.war (runtime-name: lra-cdi-check.war) in 51ms
+22:09:55,276 INFO  [org.jboss.as] (MSC service thread 1-3) WFLYSRV0050: WildFly Swarm 2017.8.1 (WildFly Core 2.2.1.Final) stopped in 54ms
+22:09:55,287 INFO  [org.jboss.weld.Bootstrap] (main) WELD-ENV-002001: Weld SE container internal shut down
+22:09:55,314 INFO  [org.wildfly.swarm] (main) WFSWARM0013: Installed fraction:                  Logging - STABLE          org.wildfly.swarm:logging:2017.8.1
+22:09:55,315 INFO  [org.wildfly.swarm] (main) WFSWARM0013: Installed fraction:          Bean Validation - STABLE          org.wildfly.swarm:bean-validation:2017.8.1
+22:09:55,315 INFO  [org.wildfly.swarm] (main) WFSWARM0013: Installed fraction:        CDI Configuration - STABLE          org.wildfly.swarm:cdi-config:2017.8.1
+22:09:55,316 INFO  [org.wildfly.swarm] (main) WFSWARM0013: Installed fraction:             Transactions - STABLE          org.wildfly.swarm:transactions:2017.8.1
+22:09:55,318 INFO  [org.wildfly.swarm] (main) WFSWARM0013: Installed fraction:                      CDI - STABLE          org.wildfly.swarm:cdi:2017.8.1
+22:09:55,319 INFO  [org.wildfly.swarm] (main) WFSWARM0013: Installed fraction:                 Undertow - STABLE          org.wildfly.swarm:undertow:2017.8.1
+22:09:55,319 INFO  [org.wildfly.swarm] (main) WFSWARM0013: Installed fraction:                   JAX-RS - STABLE          org.wildfly.swarm:jaxrs:2017.8.1
+22:09:55,695 INFO  [org.jboss.as] (MSC service thread 2-6) WFLYSRV0049: WildFly Swarm 2017.8.1 (WildFly Core 2.2.1.Final) starting
+22:09:55,700 INFO  [org.wildfly.swarm] (MSC service thread 2-6) WFSWARM0019: Install MSC service for command line args: [-Dswarm.logging.periodic-rotating-file-handlers=FILE, -Dswarm.logging.periodic-rotating-file-handlers.FILE.file.path=/tmp/junit2226099510795899201/junit8263699203951387312.tmp, -Dswarm.logging.root-logger.handlers=[CONSOLE,FILE]]
+22:18:05,870 WARN  [org.jboss.as.txn] (ServerService Thread Pool -- 13) WFLYTX0013: Node identifier property is set to the default value. Please make sure it is unique.
+22:18:05,891 INFO  [org.jboss.as.naming] (ServerService Thread Pool -- 21) WFLYNAM0001: Activating Naming Subsystem
+22:18:05,912 INFO  [org.jboss.as.security] (ServerService Thread Pool -- 19) WFLYSEC0002: Activating Security Subsystem
+22:18:05,935 INFO  [org.jboss.as.security] (MSC service thread 1-4) WFLYSEC0001: Current PicketBox version=4.9.6.Final
+22:18:05,975 INFO  [org.wildfly.extension.undertow] (MSC service thread 1-5) WFLYUT0003: Undertow 1.4.11.Final starting
+22:18:05,989 INFO  [org.wildfly.extension.io] (ServerService Thread Pool -- 16) WFLYIO001: Worker 'default' has auto-configured to 8 core threads with 64 task threads based on your 4 available processors
+22:18:06,036 INFO  [org.jboss.as.naming] (MSC service thread 1-6) WFLYNAM0003: Starting Naming Service
+22:18:06,137 INFO  [org.xnio] (MSC service thread 1-6) XNIO version 3.4.3.Final
+22:18:06,163 INFO  [org.xnio.nio] (MSC service thread 1-6) XNIO NIO Implementation Version 3.4.3.Final
+22:18:06,239 INFO  [org.wildfly.extension.undertow] (MSC service thread 1-4) WFLYUT0012: Started server default-server.
+22:18:06,406 INFO  [org.wildfly.extension.undertow] (MSC service thread 1-4) WFLYUT0006: Undertow HTTP listener default listening on [0:0:0:0:0:0:0:0]:8080
+22:18:06,602 INFO  [org.jboss.as] (Controller Boot Thread) WFLYSRV0025: WildFly Swarm 2017.8.1 (WildFly Core 2.2.1.Final) started in 1752ms - Started 88 of 97 services (18 services are lazy, passive or on-demand)
+22:18:08,151 INFO  [org.wildfly.swarm.runtime.deployer] (main) deploying lra-cdi-check.war
+22:18:08,186 INFO  [org.jboss.as.server.deployment] (MSC service thread 1-8) WFLYSRV0027: Starting deployment of "lra-cdi-check.war" (runtime-name: "lra-cdi-check.war")
+22:18:08,420 WARN  [org.jboss.as.dependency.private] (MSC service thread 1-2) WFLYSRV0018: Deployment "deployment.lra-cdi-check.war" is using a private module ("org.jboss.jts:main") which may be changed or removed in future versions without notice.
+22:18:08,482 INFO  [org.jboss.weld.deployer] (MSC service thread 1-4) WFLYWELD0003: Processing weld deployment lra-cdi-check.war
+22:18:08,758 INFO  [org.hibernate.validator.internal.util.Version] (MSC service thread 1-4) HV000001: Hibernate Validator 5.2.4.Final
+22:18:09,144 INFO  [org.jboss.weld.Version] (MSC service thread 1-1) WELD-000900: 2.3.5 (Final)
+22:18:09,187 INFO  [org.wildfly.extension.undertow] (MSC service thread 1-3) WFLYUT0018: Host default-host starting
+22:18:10,009 INFO  [org.jboss.resteasy.resteasy_jaxrs.i18n] (ServerService Thread Pool -- 8) RESTEASY002225: Deploying javax.ws.rs.core.Application: class org.wildfly.swarm.generated.WildFlySwarmDefaultJAXRSApplication$Proxy$_$$_WeldClientProxy
+22:18:10,017 INFO  [org.wildfly.extension.undertow] (ServerService Thread Pool -- 8) WFLYUT0021: Registered web context: /
+22:18:10,057 INFO  [org.jboss.as.server] (main) WFLYSRV0010: Deployed "lra-cdi-check.war" (runtime-name : "lra-cdi-check.war")
+22:18:10,069 INFO  [org.wildfly.extension.undertow] (MSC service thread 1-3) WFLYUT0008: Undertow HTTP listener default suspending
+22:18:10,077 INFO  [org.wildfly.extension.undertow] (ServerService Thread Pool -- 8) WFLYUT0022: Unregistered web context: /
+22:18:10,086 INFO  [org.wildfly.extension.undertow] (MSC service thread 1-3) WFLYUT0007: Undertow HTTP listener default stopped, was bound to [0:0:0:0:0:0:0:0]:8080
+22:18:10,095 INFO  [org.wildfly.extension.undertow] (MSC service thread 1-2) WFLYUT0019: Host default-host stopping
+22:18:10,096 INFO  [org.wildfly.extension.undertow] (MSC service thread 1-2) WFLYUT0004: Undertow 1.4.11.Final stopping
+22:18:10,141 INFO  [org.jboss.as.server.deployment] (MSC service thread 1-7) WFLYSRV0028: Stopped deployment lra-cdi-check.war (runtime-name: lra-cdi-check.war) in 77ms
+22:18:10,147 INFO  [org.jboss.as] (MSC service thread 1-3) WFLYSRV0050: WildFly Swarm 2017.8.1 (WildFly Core 2.2.1.Final) stopped in 69ms
+22:18:10,162 INFO  [org.jboss.weld.Bootstrap] (main) WELD-ENV-002001: Weld SE container internal shut down
+22:18:10,200 INFO  [org.wildfly.swarm] (main) WFSWARM0013: Installed fraction:                  Logging - STABLE          org.wildfly.swarm:logging:2017.8.1
+22:18:10,200 INFO  [org.wildfly.swarm] (main) WFSWARM0013: Installed fraction:          Bean Validation - STABLE          org.wildfly.swarm:bean-validation:2017.8.1
+22:18:10,200 INFO  [org.wildfly.swarm] (main) WFSWARM0013: Installed fraction:        CDI Configuration - STABLE          org.wildfly.swarm:cdi-config:2017.8.1
+22:18:10,201 INFO  [org.wildfly.swarm] (main) WFSWARM0013: Installed fraction:             Transactions - STABLE          org.wildfly.swarm:transactions:2017.8.1
+22:18:10,201 INFO  [org.wildfly.swarm] (main) WFSWARM0013: Installed fraction:                      CDI - STABLE          org.wildfly.swarm:cdi:2017.8.1
+22:18:10,201 INFO  [org.wildfly.swarm] (main) WFSWARM0013: Installed fraction:                 Undertow - STABLE          org.wildfly.swarm:undertow:2017.8.1
+22:18:10,201 INFO  [org.wildfly.swarm] (main) WFSWARM0013: Installed fraction:                   JAX-RS - STABLE          org.wildfly.swarm:jaxrs:2017.8.1
+22:18:10,618 INFO  [org.jboss.as] (MSC service thread 2-8) WFLYSRV0049: WildFly Swarm 2017.8.1 (WildFly Core 2.2.1.Final) starting
+22:18:10,621 INFO  [org.wildfly.swarm] (MSC service thread 2-8) WFSWARM0019: Install MSC service for command line args: [-Dswarm.logging.periodic-rotating-file-handlers=FILE, -Dswarm.logging.periodic-rotating-file-handlers.FILE.file.path=/tmp/junit3394201886381207733/junit206429401546504389.tmp, -Dswarm.logging.root-logger.handlers=[CONSOLE,FILE]]

--- a/rts/lra/lra-cdi-rest/pom.xml
+++ b/rts/lra/lra-cdi-rest/pom.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2015 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+  -->
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.jboss.narayana.rts</groupId>
+        <artifactId>lra-parent</artifactId>
+        <version>5.6.0.Final-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>lra-cdi-rest</artifactId>
+    <name>LRA Cdi REST integration</name>
+    <description>Extension which helps for easier use of LRA annotations</description>
+    <packaging>jar</packaging>
+    <build>
+        <finalName>lra-cdi-rest</finalName>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.jboss.narayana.rts</groupId>
+            <artifactId>lra-annotations</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>javax.enterprise</groupId>
+            <artifactId>cdi-api</artifactId>
+            <version>${version.cdi-api}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.spec.javax.ws.rs</groupId>
+            <artifactId>jboss-jaxrs-api_2.0_spec</artifactId>
+            <version>${version.jaxrs.api}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- Testing -->
+        <dependency>
+            <groupId>org.wildfly.swarm</groupId>
+            <artifactId>container</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.swarm</groupId>
+            <artifactId>cdi</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.swarm</groupId>
+            <artifactId>jaxrs</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.swarm</groupId>
+            <artifactId>logging</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/rts/lra/lra-cdi-rest/src/main/java/org/jboss/narayana/rts/lra/cdi/LraAnnotationProcessingExtension.java
+++ b/rts/lra/lra-cdi-rest/src/main/java/org/jboss/narayana/rts/lra/cdi/LraAnnotationProcessingExtension.java
@@ -1,0 +1,186 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.narayana.rts.lra.cdi;
+
+import java.lang.annotation.Annotation;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import javax.enterprise.event.Observes;
+import javax.enterprise.inject.spi.AnnotatedMethod;
+import javax.enterprise.inject.spi.DeploymentException;
+import javax.enterprise.inject.spi.Extension;
+import javax.enterprise.inject.spi.ProcessAnnotatedType;
+import javax.enterprise.inject.spi.WithAnnotations;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+
+import org.jboss.narayana.rts.lra.annotation.Compensate;
+import org.jboss.narayana.rts.lra.annotation.Complete;
+import org.jboss.narayana.rts.lra.annotation.Forget;
+import org.jboss.narayana.rts.lra.annotation.LRA;
+import org.jboss.narayana.rts.lra.annotation.Leave;
+import org.jboss.narayana.rts.lra.annotation.Status;
+
+
+/**
+ * <p>
+ * CDI extension working in concord of LRA filters.
+ * <p>
+ * When added at the class path of the project this extension validates
+ * if the classes contain compulsory annotation complementary to {@link LRA}.
+ * The rules of what are compulsory annotations and their attributes
+ * are defined in LRA specification.
+ * <p>
+ * In case of validity violation the {@link DeploymentException} is thrown.
+ * 
+ * @author Ondra Chaloupka <ochaloup@redhat.com>
+ */
+public class LraAnnotationProcessingExtension implements Extension {
+
+    <X> void processLraAnnotatedType(@Observes @WithAnnotations({LRA.class}) ProcessAnnotatedType<X> classAnnotatedWithLra) {
+
+        // All compulsory LRA annotations are available at the class
+        Supplier<Stream<AnnotatedMethod<? super X>>> sup = () -> classAnnotatedWithLra.getAnnotatedType().getMethods().stream();
+        Set<Class<? extends Annotation>> missing = new HashSet<>();
+        if(!sup.get().anyMatch(m -> m.isAnnotationPresent(Compensate.class))) missing.add(Compensate.class);
+        if(!sup.get().anyMatch(m -> m.isAnnotationPresent(Complete.class))) missing.add(Complete.class);
+        if(!sup.get().anyMatch(m -> m.isAnnotationPresent(Status.class))) missing.add(Status.class);
+
+        if(!missing.isEmpty()) {
+            throw new DeploymentException("Class " + classAnnotatedWithLra.getAnnotatedType().getJavaClass().getName() + " uses "
+              + LRA.class.getName() + " which requires methods handling LRA events. Missing annotations in the class: " + missing);
+        }
+
+        // Only one of the compulsory LRA annotations are placed in the class
+        List<AnnotatedMethod<? super X>> methodsWithCompensate = sup.get()
+            .filter(m -> m.isAnnotationPresent(Compensate.class))
+            .collect(Collectors.toList());
+        List<AnnotatedMethod<? super X>> methodsWithComplete = sup.get()
+            .filter(m -> m.isAnnotationPresent(Complete.class))
+            .collect(Collectors.toList());
+        List<AnnotatedMethod<? super X>> methodsWithStatus = sup.get()
+            .filter(m -> m.isAnnotationPresent(Status.class))
+            .collect(Collectors.toList());
+        List<AnnotatedMethod<? super X>> methodsWithLeave = sup.get()
+            .filter(m -> m.isAnnotationPresent(Leave.class))
+            .collect(Collectors.toList());
+        List<AnnotatedMethod<? super X>> methodsWithForget = sup.get()
+            .filter(m -> m.isAnnotationPresent(Forget.class))
+            .collect(Collectors.toList());
+
+        BiFunction<Class<?>, List<AnnotatedMethod<? super X>>, String> errorMsg = (clazz, methods) -> String.format(
+            "There are used multiple annotations '%s' in the class '%s' on methods %s. Only one per the class is expected.",
+            clazz.getName(), classAnnotatedWithLra.getAnnotatedType().getJavaClass().getName(),
+            methods.stream().map(a -> a.getJavaMember().getName()).collect(Collectors.toList()));
+        if(methodsWithCompensate.size() > 1) {
+            throw new DeploymentException(errorMsg.apply(Compensate.class, methodsWithCompensate));
+        }
+        if(methodsWithComplete.size() > 1) {
+            throw new DeploymentException(errorMsg.apply(Complete.class, methodsWithComplete));
+        }
+        if(methodsWithStatus.size() > 1) {
+            throw new DeploymentException(errorMsg.apply(Status.class, methodsWithStatus));
+        }
+        if(methodsWithLeave.size() > 1) {
+            throw new DeploymentException(errorMsg.apply(Leave.class, methodsWithLeave));
+        }
+        if(methodsWithForget.size() > 1) {
+            throw new DeploymentException(errorMsg.apply(Forget.class, methodsWithForget));
+        }
+
+        // Each method annotated with LRA-style annotations contain all necessary REST annotations
+        // @Compensate - requires @Path and @POST
+        final AnnotatedMethod<? super X> methodWithCompensate = methodsWithCompensate.get(0);
+        Function<Class<?>, String> getCompensateMissingErrMsg = (wrongAnnotation) ->
+            getMissingAnnotationError(methodWithCompensate, classAnnotatedWithLra, Compensate.class, wrongAnnotation);
+        boolean isCompensateContainsPathAnnotation = methodWithCompensate.getAnnotations().stream().anyMatch(a -> a.annotationType().equals(Path.class));
+        if(!isCompensateContainsPathAnnotation) {
+            throw new DeploymentException(getCompensateMissingErrMsg.apply(Path.class));
+        }
+        boolean isCompensateContainsPostAnnotation = methodWithCompensate.getAnnotations().stream().anyMatch(a -> a.annotationType().equals(POST.class));
+        if(!isCompensateContainsPostAnnotation) {
+            throw new DeploymentException(getCompensateMissingErrMsg.apply(POST.class));
+        }
+
+        // @Complete - requires @Path and @POST
+        final AnnotatedMethod<? super X> methodWithComplete = methodsWithComplete.get(0);
+        Function<Class<?>, String> getCompleteMissingErrMsg = (wrongAnnotation) ->
+            getMissingAnnotationError(methodWithComplete, classAnnotatedWithLra, Complete.class, wrongAnnotation);
+        boolean isCompleteContainsPathAnnotation = methodWithComplete.getAnnotations().stream().anyMatch(a -> a.annotationType().equals(Path.class));
+        if(!isCompleteContainsPathAnnotation) {
+            throw new DeploymentException(getCompleteMissingErrMsg.apply(Path.class));
+        }
+        boolean isCompleteContainsPostAnnotation = methodWithComplete.getAnnotations().stream().anyMatch(a -> a.annotationType().equals(POST.class));
+        if(!isCompleteContainsPostAnnotation) {
+            throw new DeploymentException(getCompleteMissingErrMsg.apply(POST.class));
+        }
+        
+        // @Status - requires @Path and @GET
+        final AnnotatedMethod<? super X> methodWithStatus = methodsWithStatus.get(0);
+        Function<Class<?>, String> getStatusMissingErrMsg = (wrongAnnotation) ->
+            getMissingAnnotationError(methodWithStatus, classAnnotatedWithLra, Status.class, wrongAnnotation);
+        boolean isStatusContainsPathAnnotation = methodWithStatus.getAnnotations().stream().anyMatch(a -> a.annotationType().equals(Path.class));
+        if(!isStatusContainsPathAnnotation) {
+            throw new DeploymentException(getStatusMissingErrMsg.apply(Path.class));
+        }
+        boolean isStatusContainsPostAnnotation = methodWithStatus.getAnnotations().stream().anyMatch(a -> a.annotationType().equals(GET.class));
+        if(!isStatusContainsPostAnnotation) {
+            throw new DeploymentException(getStatusMissingErrMsg.apply(GET.class));
+        }
+
+        if(methodsWithLeave.size() > 0) { 
+            // @Leave - requires @PUT
+            final AnnotatedMethod<? super X> methodWithLeave = methodsWithLeave.get(0);
+            boolean isLeaveContainsPutAnnotation = methodWithLeave.getAnnotations().stream().anyMatch(a -> a.annotationType().equals(PUT.class));
+            if(!isLeaveContainsPutAnnotation) {
+                throw new DeploymentException(getMissingAnnotationError(methodWithLeave, classAnnotatedWithLra, Leave.class, PUT.class));
+            }
+        }
+        
+        if(methodsWithForget.size() > 0) {
+            // @Forget - requires @DELETE
+            final AnnotatedMethod<? super X> methodWithForget = methodsWithForget.get(0);
+            boolean isForgetContainsPutAnnotation = methodWithForget.getAnnotations().stream().anyMatch(a -> a.annotationType().equals(DELETE.class));
+            if(!isForgetContainsPutAnnotation) {
+                throw new DeploymentException(getMissingAnnotationError(methodWithForget, classAnnotatedWithLra, Forget.class, DELETE.class));
+            }
+        }
+    }
+
+    private String getMissingAnnotationError(AnnotatedMethod<?> method, ProcessAnnotatedType<?> classAnnotated,
+        Class<?> lraTypeAnnotation, Class<?> complementaryAnnotation) {
+        return String.format("Method '%s' of class '%s' annotated by '%s' should use complementary annotation %s",
+            method.getJavaMember().getName(), classAnnotated.getAnnotatedType().getJavaClass().getName(),
+            lraTypeAnnotation.getName(), complementaryAnnotation.getName());
+    }
+}

--- a/rts/lra/lra-cdi-rest/src/main/resources/META-INF/services/javax.enterprise.inject.spi.Extension
+++ b/rts/lra/lra-cdi-rest/src/main/resources/META-INF/services/javax.enterprise.inject.spi.Extension
@@ -1,0 +1,1 @@
+org.jboss.narayana.rts.lra.cdi.LraAnnotationProcessingExtension

--- a/rts/lra/lra-cdi-rest/src/test/java/org/jboss/narayana/rts/lra/cdi/test/StartCdiCheckIT.java
+++ b/rts/lra/lra-cdi-rest/src/test/java/org/jboss/narayana/rts/lra/cdi/test/StartCdiCheckIT.java
@@ -1,0 +1,180 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.narayana.rts.lra.cdi.test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.List;
+
+import org.jboss.narayana.rts.lra.annotation.Forget;
+import org.jboss.narayana.rts.lra.cdi.LraAnnotationProcessingExtension;
+import org.jboss.narayana.rts.lra.cdi.test.bean.OnlyOneLraAnnotationBean;
+import org.jboss.narayana.rts.lra.cdi.test.bean.OnlyTwoLraAnnotationsBean;
+import org.jboss.narayana.rts.lra.cdi.test.bean.AllAnnotationsNoPathBean;
+import org.jboss.narayana.rts.lra.cdi.test.bean.CorrectBean;
+import org.jboss.narayana.rts.lra.cdi.test.bean.ForgetWithoutDeleteBean;
+import org.jboss.narayana.rts.lra.cdi.test.bean.LeaveWithoutPutBean;
+import org.jboss.narayana.rts.lra.cdi.test.bean.MultiForgetBean;
+import org.jboss.narayana.rts.lra.cdi.test.bean.NoPostOrGetBean;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.resolver.api.maven.Maven;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.wildfly.swarm.Swarm;
+import org.wildfly.swarm.cdi.CDIFraction;
+import org.wildfly.swarm.jaxrs.JAXRSFraction;
+
+import com.google.common.collect.Lists;
+
+/**
+ * Test case which checks functionality of CDI extension by deploying wrongly
+ * composed LRA components and expect an deployment exception to be thrown.
+ *
+ * @author Ondra Chaloupka <ochaloup@redhat.com>
+ */
+public class StartCdiCheckIT {
+
+    @Rule
+    public TemporaryFolder tmpFolder = new TemporaryFolder();
+
+    @Test
+    public void onlyCompensateAnnotationPresent() throws Exception {
+        checkSwarmWithDeploymentException("LRA which requires methods handling LRA events. Missing annotations",
+            OnlyOneLraAnnotationBean.class);
+    }
+
+    @Test
+    public void onlyCompleteAndStatusAnnotationsPresent() throws Exception {
+        checkSwarmWithDeploymentException("LRA which requires methods handling LRA events. Missing annotations",
+            OnlyTwoLraAnnotationsBean.class);
+    }
+    
+    @Test
+    public void complementaryPathAnnotation() throws Exception {
+        checkSwarmWithDeploymentException("should use complementary annotation.*Path",
+            AllAnnotationsNoPathBean.class);
+    }
+    
+    @Test
+    public void methodTypeAnnotationMissing() throws Exception {
+        checkSwarmWithDeploymentException("should use complementary annotation.*(POST|GET)",
+            NoPostOrGetBean.class);
+    }
+    
+    @Test
+    public void forgetMissingDelete() throws Exception {
+        checkSwarmWithDeploymentException("should use complementary annotation.*(DELETE)",
+            ForgetWithoutDeleteBean.class);
+    }
+    
+    @Test
+    public void leaveMissingPut() throws Exception {
+        checkSwarmWithDeploymentException("should use complementary annotation.*(PUT)",
+            LeaveWithoutPutBean.class);
+    }
+    
+    @Test
+    public void multiForgetAnnotations() throws Exception {
+        checkSwarmWithDeploymentException("multiple annotations.*" + Forget.class.getName(),
+            MultiForgetBean.class);
+    }
+
+    @Test
+    public void allCorrect() throws Exception {
+        Swarm swarm = new Swarm()
+            .fraction(new JAXRSFraction())
+            .fraction(new CDIFraction())
+            .start();
+
+        try {
+            swarm.deploy(getBaseDeployment().addClasses(CorrectBean.class));
+        } finally {
+            swarm.stop();
+        }
+    }
+
+    private static List<String> loggingArgs = Arrays.asList(new String[] {
+            "-Dswarm.logging.periodic-rotating-file-handlers=FILE",
+            "-Dswarm.logging.periodic-rotating-file-handlers.FILE.file.path=%s",
+            "-Dswarm.logging.root-logger.handlers=[CONSOLE,FILE]"
+        });
+
+    private WebArchive getBaseDeployment() {
+        WebArchive deployment = ShrinkWrap.create(WebArchive.class, "lra-cdi-check.war")
+            .addClass(LraAnnotationProcessingExtension.class)
+            .addAsManifestResource(new StringAsset(LraAnnotationProcessingExtension.class.getName()),
+                "services/javax.enterprise.inject.spi.Extension")
+            .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+        
+        File[] libs = Maven.resolver()
+            .loadPomFromFile("pom.xml")
+            .resolve("org.jboss.narayana.rts:lra-annotations")
+            .withTransitivity().as(File.class); 
+        deployment.addAsLibraries(libs);
+        
+        return deployment;
+    }
+
+    private String[] getLoggingArgs(final File logFile) {
+        return Lists.transform(loggingArgs, inputString -> {
+           String outString = inputString;
+           if(inputString.contains("path")) outString = String.format(inputString, logFile.getAbsolutePath());
+           return outString;
+        }).toArray(new String[]{});
+    }
+
+    private void checkSwarmWithDeploymentException(String stringToMatch, Class<?>... classesToAdd) throws Exception {
+        File logFile = tmpFolder.newFile();
+
+        Swarm swarm = new Swarm(getLoggingArgs(logFile))
+            .fraction(new JAXRSFraction())
+            .fraction(new CDIFraction())
+            .start();
+
+        try {
+            swarm
+                .deploy(getBaseDeployment().addClasses(classesToAdd));
+            Assert.fail("Expected deployment exception to be thrown");
+        } catch (org.wildfly.swarm.container.DeploymentException de) {
+            // expected
+        } finally {
+            swarm.stop();
+        }
+
+        assertLogLine(logFile, stringToMatch);
+    }
+
+    private void assertLogLine(File file, String expectedString) throws IOException {
+        Assert.assertNotNull("file", file);
+        boolean isContain = Files.readAllLines(file.toPath()).stream()
+            .anyMatch(line -> line.matches(".*" + expectedString + ".*"));
+        Assert.assertTrue("Log file does not contain '" + expectedString + "'", isContain);
+    }
+}

--- a/rts/lra/lra-cdi-rest/src/test/java/org/jboss/narayana/rts/lra/cdi/test/bean/AllAnnotationsNoPathBean.java
+++ b/rts/lra/lra-cdi-rest/src/test/java/org/jboss/narayana/rts/lra/cdi/test/bean/AllAnnotationsNoPathBean.java
@@ -1,0 +1,51 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.narayana.rts.lra.cdi.test.bean;
+
+import org.jboss.narayana.rts.lra.annotation.Compensate;
+import org.jboss.narayana.rts.lra.annotation.Complete;
+import org.jboss.narayana.rts.lra.annotation.LRA;
+import org.jboss.narayana.rts.lra.annotation.Status;
+
+/**
+ *
+ * @author Ondra Chaloupka <ochaloup@redhat.com>
+ */
+@LRA
+public class AllAnnotationsNoPathBean {
+
+    @Complete
+    public void complete() {
+        // no implementation needed
+    }
+    
+    @Compensate
+    public void compensate() {
+        // no implementation needed
+    }
+    
+    @Status
+    public void status() {
+        // no implementation needed
+    }
+}

--- a/rts/lra/lra-cdi-rest/src/test/java/org/jboss/narayana/rts/lra/cdi/test/bean/CorrectBean.java
+++ b/rts/lra/lra-cdi-rest/src/test/java/org/jboss/narayana/rts/lra/cdi/test/bean/CorrectBean.java
@@ -1,0 +1,56 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.narayana.rts.lra.cdi.test.bean;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+
+import org.jboss.narayana.rts.lra.annotation.Compensate;
+import org.jboss.narayana.rts.lra.annotation.Complete;
+import org.jboss.narayana.rts.lra.annotation.LRA;
+import org.jboss.narayana.rts.lra.annotation.Status;
+
+@LRA
+public class CorrectBean {
+    @Complete
+    @Path("complete")
+    @POST
+    public void complete() {
+        // no implementation needed
+    }
+    
+    @Compensate
+    @Path("compensate")
+    @POST
+    public void compensate() {
+        // no implementation needed
+    }
+    
+    @Status
+    @Path("status")
+    @GET
+    public void status() {
+        // no implementation needed
+    }
+}

--- a/rts/lra/lra-cdi-rest/src/test/java/org/jboss/narayana/rts/lra/cdi/test/bean/ForgetWithoutDeleteBean.java
+++ b/rts/lra/lra-cdi-rest/src/test/java/org/jboss/narayana/rts/lra/cdi/test/bean/ForgetWithoutDeleteBean.java
@@ -1,0 +1,62 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.narayana.rts.lra.cdi.test.bean;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+
+import org.jboss.narayana.rts.lra.annotation.Compensate;
+import org.jboss.narayana.rts.lra.annotation.Complete;
+import org.jboss.narayana.rts.lra.annotation.Forget;
+import org.jboss.narayana.rts.lra.annotation.LRA;
+import org.jboss.narayana.rts.lra.annotation.Status;
+
+@LRA
+public class ForgetWithoutDeleteBean {
+    @Complete
+    @Path("complete")
+    @POST
+    public void complete() {
+        // no implementation needed
+    }
+    
+    @Compensate
+    @Path("compensate")
+    @POST
+    public void compensate() {
+        // no implementation needed
+    }
+    
+    @Status
+    @Path("status")
+    @GET
+    public void status() {
+        // no implementation needed
+    }
+
+    @Forget
+    public void forget() {
+        // no implementation needed
+    }
+}

--- a/rts/lra/lra-cdi-rest/src/test/java/org/jboss/narayana/rts/lra/cdi/test/bean/LeaveWithoutPutBean.java
+++ b/rts/lra/lra-cdi-rest/src/test/java/org/jboss/narayana/rts/lra/cdi/test/bean/LeaveWithoutPutBean.java
@@ -1,0 +1,62 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.narayana.rts.lra.cdi.test.bean;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+
+import org.jboss.narayana.rts.lra.annotation.Compensate;
+import org.jboss.narayana.rts.lra.annotation.Complete;
+import org.jboss.narayana.rts.lra.annotation.LRA;
+import org.jboss.narayana.rts.lra.annotation.Leave;
+import org.jboss.narayana.rts.lra.annotation.Status;
+
+@LRA
+public class LeaveWithoutPutBean {
+    @Complete
+    @Path("complete")
+    @POST
+    public void complete() {
+        // no implementation needed
+    }
+    
+    @Compensate
+    @Path("compensate")
+    @POST
+    public void compensate() {
+        // no implementation needed
+    }
+    
+    @Status
+    @Path("status")
+    @GET
+    public void status() {
+        // no implementation needed
+    }
+
+    @Leave
+    public void leave() {
+        // no implementation needed
+    }
+}

--- a/rts/lra/lra-cdi-rest/src/test/java/org/jboss/narayana/rts/lra/cdi/test/bean/MultiForgetBean.java
+++ b/rts/lra/lra-cdi-rest/src/test/java/org/jboss/narayana/rts/lra/cdi/test/bean/MultiForgetBean.java
@@ -1,0 +1,70 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.narayana.rts.lra.cdi.test.bean;
+
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+
+import org.jboss.narayana.rts.lra.annotation.Compensate;
+import org.jboss.narayana.rts.lra.annotation.Complete;
+import org.jboss.narayana.rts.lra.annotation.Forget;
+import org.jboss.narayana.rts.lra.annotation.LRA;
+import org.jboss.narayana.rts.lra.annotation.Status;
+
+@LRA
+public class MultiForgetBean {
+    @Complete
+    @Path("complete")
+    @POST
+    public void complete() {
+        // no implementation needed
+    }
+    
+    @Compensate
+    @Path("compensate")
+    @POST
+    public void compensate() {
+        // no implementation needed
+    }
+    
+    @Status
+    @Path("status")
+    @GET
+    public void status() {
+        // no implementation needed
+    }
+
+    @Forget
+    @DELETE
+    public void foget1() {
+        // no implementation needed
+    }
+    
+    @Forget
+    @DELETE
+    public void foget2() {
+        // no implementation needed
+    }
+}

--- a/rts/lra/lra-cdi-rest/src/test/java/org/jboss/narayana/rts/lra/cdi/test/bean/NoPostOrGetBean.java
+++ b/rts/lra/lra-cdi-rest/src/test/java/org/jboss/narayana/rts/lra/cdi/test/bean/NoPostOrGetBean.java
@@ -1,0 +1,52 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.narayana.rts.lra.cdi.test.bean;
+
+import javax.ws.rs.Path;
+
+import org.jboss.narayana.rts.lra.annotation.Compensate;
+import org.jboss.narayana.rts.lra.annotation.Complete;
+import org.jboss.narayana.rts.lra.annotation.LRA;
+import org.jboss.narayana.rts.lra.annotation.Status;
+
+@LRA
+public class NoPostOrGetBean {
+    
+    @Path("/complete")
+    @Complete
+    public void complete() {
+        // no implementation needed
+    }
+    
+    @Path("/compensate")
+    @Compensate
+    public void compensate() {
+        // no implementation needed
+    }
+    
+    @Path("/status")
+    @Status
+    public void status() {
+        // no implementation needed
+    }
+}

--- a/rts/lra/lra-cdi-rest/src/test/java/org/jboss/narayana/rts/lra/cdi/test/bean/OnlyOneLraAnnotationBean.java
+++ b/rts/lra/lra-cdi-rest/src/test/java/org/jboss/narayana/rts/lra/cdi/test/bean/OnlyOneLraAnnotationBean.java
@@ -1,0 +1,43 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.narayana.rts.lra.cdi.test.bean;
+
+import org.jboss.narayana.rts.lra.annotation.Compensate;
+import org.jboss.narayana.rts.lra.annotation.Complete;
+import org.jboss.narayana.rts.lra.annotation.Status;
+import org.jboss.narayana.rts.lra.annotation.LRA;
+
+/**
+ * {@link LRA} bean which contains only one annotation - {@link Compensate}
+ * but the LRA prescribe for the bean to contain three: {@link Compensate}, {@link Complete} and {@link Status}.
+ *
+ * @author Ondra Chaloupka <ochaloup@redhat.com>
+ */
+@LRA
+public class OnlyOneLraAnnotationBean {
+
+    @Compensate
+    public void compensate() {
+        // no implementation
+    }
+}

--- a/rts/lra/lra-cdi-rest/src/test/java/org/jboss/narayana/rts/lra/cdi/test/bean/OnlyTwoLraAnnotationsBean.java
+++ b/rts/lra/lra-cdi-rest/src/test/java/org/jboss/narayana/rts/lra/cdi/test/bean/OnlyTwoLraAnnotationsBean.java
@@ -1,0 +1,48 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.narayana.rts.lra.cdi.test.bean;
+
+import org.jboss.narayana.rts.lra.annotation.Compensate;
+import org.jboss.narayana.rts.lra.annotation.Complete;
+import org.jboss.narayana.rts.lra.annotation.LRA;
+import org.jboss.narayana.rts.lra.annotation.Status;
+
+/**
+ * {@link LRA} bean which contains only two annotations - {@link Complete} and {@link Status} 
+ * but the LRA prescribe for the bean to contain three: {@link Compensate}, {@link Complete} and {@link Status}.
+ *
+ * @author Ondra Chaloupka <ochaloup@redhat.com>
+ */
+@LRA
+public class OnlyTwoLraAnnotationsBean {
+
+    @Complete
+    public void complete() {
+        // no implementation needed
+    }
+    
+    @Status
+    public void status() {
+        // no implementation needed
+    }
+}

--- a/rts/lra/lra-cdi-rest/src/test/resources/project-defaults.yml
+++ b/rts/lra/lra-cdi-rest/src/test/resources/project-defaults.yml
@@ -1,0 +1,16 @@
+swarm:
+  logging:
+    pattern-formatters:
+      COLOR_PATTERN:
+        pattern: "CUSTOM LOG FORMAT %p [%c] %s%e%n"
+    periodic-rotating-file-handlers:
+      FILE:
+        file:
+          path: foobar.log
+          relative-to: jboss.server.log.dir
+        append: true
+        suffix: .yyyy-MM-dd
+    root-logger:
+      handlers:
+        - CONSOLE
+        - FILE

--- a/rts/lra/lra-client/pom.xml
+++ b/rts/lra/lra-client/pom.xml
@@ -35,6 +35,12 @@
             <version>1.0.0.Final</version>
         </dependency>
         <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${version.jackson}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>javax.enterprise</groupId>
             <artifactId>cdi-api</artifactId>
             <version>${version.cdi-api}</version>
@@ -46,37 +52,12 @@
             <version>2.5</version>
             <scope>provided</scope>
         </dependency>
-
-        <dependency>
-            <groupId>org.wildfly.swarm</groupId>
-            <artifactId>microprofile</artifactId>
-            <version>${version.wildfly-swarm}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>${version.junit}</version>
-            <scope>test</scope>
-        </dependency>
         <!-- JAXRS 2 Client API -->
         <dependency>
             <groupId>org.jboss.spec.javax.ws.rs</groupId>
             <artifactId>jboss-jaxrs-api_2.0_spec</artifactId>
             <version>${version.jaxrs.api}</version>
             <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-            <version>2.8.9</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.resteasy</groupId>
-            <artifactId>resteasy-client</artifactId>
-            <version>${version.resteasy-client}</version>
-            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/rts/lra/lra-client/pom.xml
+++ b/rts/lra/lra-client/pom.xml
@@ -9,7 +9,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.jboss.narayana.rts</groupId>
-        <artifactId>rest-lra-parent</artifactId>
+        <artifactId>lra-parent</artifactId>
         <version>5.6.0.Final-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>

--- a/rts/lra/lra-client/src/main/java/org/jboss/narayana/rts/lra/client/LRAClient.java
+++ b/rts/lra/lra-client/src/main/java/org/jboss/narayana/rts/lra/client/LRAClient.java
@@ -207,7 +207,7 @@ public class LRAClient implements LRAClientAPI, Closeable {
     }
 
     private WebTarget getTarget() {
-//        return target; // TODO can't share the target if a sra.demo.service makes multiple JAX-RS requests
+//        return target; // TODO can't share the target if a lra.demo.service makes multiple JAX-RS requests
         client.close(); // hacking
         client = ClientBuilder.newClient();
         return client.target(base);

--- a/rts/lra/lra-client/src/main/java/org/jboss/narayana/rts/lra/client/LRAClient.java
+++ b/rts/lra/lra-client/src/main/java/org/jboss/narayana/rts/lra/client/LRAClient.java
@@ -299,7 +299,7 @@ public class LRAClient implements LRAClientAPI, Closeable {
     public void renewTimeLimit(URL lraId, long limit, TimeUnit unit) {
         Response response = null;
 
-        lraTrace("leaving LRA", lraId);
+        lraTrace(String.format("renew time limit to %s s of LRA", unit.toSeconds(limit)), lraId);
 
         try {
             aquireConnection();

--- a/rts/lra/lra-client/src/main/java/org/jboss/narayana/rts/lra/client/LRAClientAPI.java
+++ b/rts/lra/lra-client/src/main/java/org/jboss/narayana/rts/lra/client/LRAClientAPI.java
@@ -30,7 +30,7 @@ public interface LRAClientAPI {
     /**
      * Start a new LRA
      *
-     * The LRA sra.demo.model uses a presumed nothing protocol: the coordinator must communicate with Compensators
+     * The LRA lra.demo.model uses a presumed nothing protocol: the coordinator must communicate with Compensators
      * in order to inform them of the LRA activity. Every time a Compensator is enrolled with a LRA, the
      * coordinator must make information about it durable so that the Compensator can be contacted when
      * the LRA terminates, even in the event of subsequent failures. Compensators, clients and coordinators
@@ -149,9 +149,9 @@ public interface LRAClientAPI {
      * 
      * @param lraId   The unique identifier of the LRA (required)
      * @param timelimit The time limit (in seconds) that the Compensator can guarantee that it
-     *                can compensate the work performed by the sra.demo.service. After this time period has elapsed,
+     *                can compensate the work performed by the lra.demo.service. After this time period has elapsed,
      *                it may no longer be possible to undo the work within the scope of this (or any enclosing)
-     *                LRA. It may therefore be necessary for the application or sra.demo.service to start other
+     *                LRA. It may therefore be necessary for the application or lra.demo.service to start other
      *                activities to explicitly try to compensate this work. The application or coordinator may
      *                use this information to control the lifecycle of a LRA. (required)
      * @param body    The resource path that the LRA coordinator will use to drive the compensator.
@@ -184,7 +184,7 @@ public interface LRAClientAPI {
      *
      * @param lraId The unique identifier of the LRA (required)
      * @param timelimit The time limit (in seconds) that the Compensator can guarantee that it
-     *                can compensate the work performed by the sra.demo.service
+     *                can compensate the work performed by the lra.demo.service
      * @param compensateUrl Performing a POST onthis URL will cause the participant to compensate the work that
      *                      was done within the scope of the LRA.
      * @param completeUrl Performing a POST on this URL  will cause the participant to tidy up and it can forget this transaction.

--- a/rts/lra/lra-coordinator/pom.xml
+++ b/rts/lra/lra-coordinator/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.jboss.narayana.rts</groupId>
-        <artifactId>rest-lra-parent</artifactId>
+        <artifactId>lra-parent</artifactId>
         <version>5.6.0.Final-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>

--- a/rts/lra/lra-coordinator/pom.xml
+++ b/rts/lra/lra-coordinator/pom.xml
@@ -12,7 +12,6 @@
 
     <artifactId>lra-coordinator</artifactId>
     <name>LRA Coordinator</name>
-    <version>5.6.0.Final-SNAPSHOT</version>
     <packaging>war</packaging>
 
     <properties>
@@ -23,30 +22,6 @@
         <swarm.http.port>8080</swarm.http.port>
     </properties>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>org.wildfly.swarm</groupId>
-                <artifactId>bom</artifactId>
-                <version>${version.wildfly-swarm}</version>
-                <scope>import</scope>
-                <type>pom</type>
-            </dependency>
-
-            <dependency>
-                <groupId>org.jboss.arquillian</groupId>
-                <artifactId>arquillian-bom</artifactId>
-                <version>1.1.12.Final</version>
-                <scope>import</scope>
-                <type>pom</type>
-            </dependency>
-            <dependency>
-                <groupId>org.jboss.arquillian.container</groupId>
-                <artifactId>arquillian-container-test-api</artifactId>
-                <version>1.1.12.Final</version>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
     <build>
         <finalName>lra-coordinator</finalName>
         <plugins>
@@ -70,37 +45,6 @@
                     </properties>
                 </configuration>
             </plugin>
-
-            <plugin>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <!-- tests are run using the failsafe plugin -->
-                    <skip>true</skip>
-                    <systemPropertyVariables>
-                        <arquillian.xml>arquillian-swarm.xml</arquillian.xml>
-                    </systemPropertyVariables>
-                </configuration>
-            </plugin>
-
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>failsafe-maven-plugin</artifactId>
-                <version>2.4.3-alpha-1</version>
-                <configuration>
-                    <systemProperties>
-                        <arquillian.xml>arquillian-swarm.xml</arquillian.xml>
-                    </systemProperties>
-                </configuration>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>integration-test</goal>
-                            <goal>verify</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-
         </plugins>
     </build>
 
@@ -116,7 +60,6 @@
         <dependency>
             <groupId>org.wildfly.swarm</groupId>
             <artifactId>swagger</artifactId>
-            <version>${version.wildfly-swarm}</version>
         </dependency>
 
         <dependency>
@@ -130,29 +73,23 @@
             <version>${narayana.version}</version>
         </dependency>
 
+        <!-- For swarm plugin to run -->
         <dependency>
-            <groupId>org.projectlombok</groupId>
-            <artifactId>lombok</artifactId>
-            <version>1.16.4</version>
+            <groupId>org.jboss.shrinkwrap</groupId>
+            <artifactId>shrinkwrap-impl-base</artifactId>
+            <scope>runtime</scope>
         </dependency>
 
+        <!-- Testing -->
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-client</artifactId>
             <version>${version.resteasy-client}</version>
             <scope>test</scope>
         </dependency>
-
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.12</version>
-            <scope>test</scope>
-        </dependency>
         <dependency>
             <groupId>org.wildfly.swarm</groupId>
             <artifactId>arquillian</artifactId>
-            <version>${version.wildfly-swarm}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/rts/lra/lra-coordinator/src/main/java/org/jboss/narayana/rts/lra/coordinator/api/Coordinator.java
+++ b/rts/lra/lra-coordinator/src/main/java/org/jboss/narayana/rts/lra/coordinator/api/Coordinator.java
@@ -148,7 +148,7 @@ public class Coordinator {
     @Path("start")
     @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_PLAIN})
     @ApiOperation(value = "Start a new LRA",
-            notes = "The LRA sra.demo.model uses a presumed nothing protocol: the coordinator must communicate\n"
+            notes = "The LRA lra.demo.model uses a presumed nothing protocol: the coordinator must communicate\n"
                     + "with Compensators in order to inform them of the LRA activity. Every time a\n"
                     + "Compensator is enrolled with a LRA, the coordinator must make information about\n"
                     + "it durable so that the Compensator can be contacted when the LRA terminates,\n"
@@ -381,9 +381,9 @@ public class Coordinator {
                     + " complete, compensate and status",
                     required = true )
             @HeaderParam("Link") String linkHeader,
-            @ApiParam( value = "The time limit (in seconds) that the Compensator can guarantee that it can compensate the work performed by the sra.demo.service."
+            @ApiParam( value = "The time limit (in seconds) that the Compensator can guarantee that it can compensate the work performed by the lra.demo.service."
                     + " After this time period has elapsed, it may no longer be possible to undo the work within the scope of this (or any enclosing) LRA."
-                    + " It may therefore be necessary for the application or sra.demo.service to start other activities to explicitly try to compensate this work."
+                    + " It may therefore be necessary for the application or lra.demo.service to start other activities to explicitly try to compensate this work."
                     + " The application or coordinator may use this information to control the lifecycle of a LRA.",
                     required = true )
             @QueryParam(TIMELIMIT_PARAM_NAME) @DefaultValue("0") long timeLimit,
@@ -413,9 +413,9 @@ public class Coordinator {
     public Response joinLRAViaBody(
             @ApiParam( value = "The unique identifier of the LRA", required = true )
             @PathParam("LraId")String lraId,
-            @ApiParam( value = "The time limit (in seconds) that the Compensator can guarantee that it can compensate the work performed by the sra.demo.service."
+            @ApiParam( value = "The time limit (in seconds) that the Compensator can guarantee that it can compensate the work performed by the lra.demo.service."
                     + " After this time period has elapsed, it may no longer be possible to undo the work within the scope of this (or any enclosing) LRA."
-                    + " It may therefore be necessary for the application or sra.demo.service to start other activities to explicitly try to compensate this work."
+                    + " It may therefore be necessary for the application or lra.demo.service to start other activities to explicitly try to compensate this work."
                     + " The application or coordinator may use this information to control the lifecycle of a LRA.",
                     required = true )
             @QueryParam(TIMELIMIT_PARAM_NAME) @DefaultValue("0") int timeLimit,

--- a/rts/lra/lra-coordinator/src/main/java/org/jboss/narayana/rts/lra/coordinator/domain/model/Transaction.java
+++ b/rts/lra/lra-coordinator/src/main/java/org/jboss/narayana/rts/lra/coordinator/domain/model/Transaction.java
@@ -151,7 +151,7 @@ public class Transaction extends AtomicAction { //org.jboss.jbossts.star.resourc
                  * TODO this is wrong - we should be hooking into ActionType.NESTED ... but
                  * Unfortunatly that means that after a nested txn is committed its participants are merged
                  * with the parent and they can then only be aborted if the parent aborts whereas in
-                 * the LRA sra.demo.model nested LRAs can be compensated whilst the enclosing LRA is completed
+                 * the LRA lra.demo.model nested LRAs can be compensated whilst the enclosing LRA is completed
                  */
 
                 // repopulate the pending list TODO it won't neccessarily be present during recovery

--- a/rts/lra/lra-coordinator/src/test/resources/META-INF/services/javax.ws.rs.client.ClientBuilder
+++ b/rts/lra/lra-coordinator/src/test/resources/META-INF/services/javax.ws.rs.client.ClientBuilder
@@ -1,1 +1,0 @@
-org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder

--- a/rts/lra/lra-filters/pom.xml
+++ b/rts/lra/lra-filters/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.jboss.narayana.rts</groupId>
-        <artifactId>rest-lra-parent</artifactId>
+        <artifactId>lra-parent</artifactId>
         <version>5.6.0.Final-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>

--- a/rts/lra/lra-filters/src/main/java/org/jboss/narayana/rts/lra/filter/ServerLRAFilter.java
+++ b/rts/lra/lra-filters/src/main/java/org/jboss/narayana/rts/lra/filter/ServerLRAFilter.java
@@ -94,7 +94,7 @@ public class ServerLRAFilter implements ContainerRequestFilter, ContainerRespons
 
 //    // TODO figure out how to disable the filters for the coordinator (they remove the
 //    private boolean isCoordinator() {
-//        return resourceInfo.getResourceClass().getName().equals("org.jboss.narayana.rts.lra.coordinator.sra.demo.api.Coordinator")
+//        return resourceInfo.getResourceClass().getName().equals("org.jboss.narayana.rts.lra.coordinator.lra.demo.api.Coordinator")
 //    }
 
     @Override

--- a/rts/lra/lra-filters/src/main/resources/META-INF/services/javax.ws.rs.ext.Providers
+++ b/rts/lra/lra-filters/src/main/resources/META-INF/services/javax.ws.rs.ext.Providers
@@ -1,3 +1,0 @@
-org.jboss.narayana.rts.lra.filter.ClientLRAResponseFilter
-org.jboss.narayana.rts.lra.filter.ClientLRARequestFilter
-

--- a/rts/lra/lra-test/pom.xml
+++ b/rts/lra/lra-test/pom.xml
@@ -22,6 +22,10 @@
         <lra.http.host>localhost</lra.http.host>
         <lra.http.port>8080</lra.http.port>
         <service.http.port>${swarm.http.port}</service.http.port>
+
+        <swarm.debug.params></swarm.debug.params>
+        <swarm.logging.params></swarm.logging.params>
+        <swarm.debug.port>8787</swarm.debug.port>
     </properties>
 
     <build>
@@ -49,55 +53,15 @@
                     </properties>
                 </configuration>
             </plugin>
-
             <plugin>
-                <artifactId>maven-antrun-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>start</id>
-                        <phase>pre-integration-test</phase>
-                        <goals>
-                            <goal>run</goal>
-                        </goals>
-                        <configuration>
-                            <target>
-                                <property name="runtime_classpath" refid="maven.runtime.classpath"/>
-                                <java jar="../lra-coordinator/target/lra-coordinator-swarm.jar" spawn="true" fork="true">
-                                </java>
-                            </target>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>stop</id>
-                        <phase>post-integration-test</phase>
-                        <goals>
-                            <goal>run</goal>
-                        </goals>
-                        <configuration>
-                            <target>
-                                <exec executable="${JAVA_HOME}/bin/jps">
-                                    <arg value="-l" />
-                                    <redirector outputproperty="process.pid">
-                                        <outputfilterchain>
-                                            <linecontains>
-                                                <contains value="lra-coordinator-swarm.jar" />
-                                            </linecontains>
-                                            <replaceregex pattern=" .*lra-coordinator-swarm.jar" replace="" flags="i"/>
-                                        </outputfilterchain>
-                                    </redirector>
-                                </exec>
-                                <exec executable="taskkill" osfamily="winnt">
-                                    <arg value="/PID" />
-                                    <arg value="${process.pid}" />
-                                </exec>
-                                <exec executable="kill" osfamily="unix">
-                                    <arg value="-15" />
-                                    <arg value="${process.pid}" />
-                                </exec>
-                            </target>
-                        </configuration>
-                    </execution>
-                </executions>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <configuration>
+                    <systemPropertyVariables combine.children="append">
+                        <swarm.debug.params>${swarm.debug.params}</swarm.debug.params>
+                        <swarm.logging.params>${swarm.logging.params}</swarm.logging.params>
+                    </systemPropertyVariables>
+                </configuration>
             </plugin>
         </plugins>
     </build>
@@ -114,6 +78,7 @@
             <groupId>org.jboss.narayana.rts</groupId>
             <artifactId>lra-filters</artifactId>
             <version>${project.version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
@@ -135,4 +100,89 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <profiles>
+        <profile>
+            <id>debug.swarm.tests</id>
+            <activation>
+                <property>
+                    <name>debug</name>
+                </property>
+            </activation>
+            <properties>
+                <swarm.debug.params>-Xrunjdwp:transport=dt_socket,address=${swarm.debug.port},server=y,suspend=y</swarm.debug.params>
+            </properties>
+        </profile>
+        <profile>
+            <id>trace.swarm</id>
+            <activation>
+                <property>
+                    <name>trace</name>
+                </property>
+            </activation>
+            <properties>
+                <swarm.logging.params>-Dswarm.logging=TRACE</swarm.logging.params>
+            </properties>
+        </profile>
+        <profile>
+            <id>start.lra.coodinator.before.it.tests</id>
+            <activation>
+                <property>
+                    <name>!no.lra.coordinator</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>start</id>
+                                <phase>pre-integration-test</phase>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                                <configuration>
+                                    <target>
+                                        <property name="runtime_classpath" refid="maven.runtime.classpath"/>
+                                        <java jar="../lra-coordinator/target/lra-coordinator-swarm.jar" spawn="true" fork="true" />
+                                    </target>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>stop</id>
+                                <phase>post-integration-test</phase>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                                <configuration>
+                                    <target>
+                                        <exec executable="${JAVA_HOME}/bin/jps">
+                                            <arg value="-l" />
+                                            <redirector outputproperty="process.pid">
+                                                <outputfilterchain>
+                                                    <linecontains>
+                                                        <contains value="lra-coordinator-swarm.jar" />
+                                                    </linecontains>
+                                                    <replaceregex pattern=" .*lra-coordinator-swarm.jar" replace="" flags="i"/>
+                                                </outputfilterchain>
+                                            </redirector>
+                                        </exec>
+                                        <exec executable="taskkill" osfamily="winnt">
+                                            <arg value="/PID" />
+                                            <arg value="${process.pid}" />
+                                        </exec>
+                                        <exec executable="kill" osfamily="unix">
+                                            <arg value="-15" />
+                                            <arg value="${process.pid}" />
+                                        </exec>
+                                    </target>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/rts/lra/lra-test/pom.xml
+++ b/rts/lra/lra-test/pom.xml
@@ -24,17 +24,6 @@
         <service.http.port>${swarm.http.port}</service.http.port>
     </properties>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>org.wildfly.swarm</groupId>
-                <artifactId>bom</artifactId>
-                <version>${version.wildfly-swarm}</version>
-                <scope>import</scope>
-                <type>pom</type>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
     <build>
         <finalName>lra-test</finalName>
         <plugins>
@@ -42,13 +31,6 @@
                 <groupId>org.wildfly.swarm</groupId>
                 <artifactId>wildfly-swarm-plugin</artifactId>
                 <version>${version.wildfly-swarm}</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>package</goal>
-                        </goals>
-                    </execution>
-                </executions>
                 <configuration>
                     <environment>
                         <swarm.http.port>${swarm.http.port}</swarm.http.port>
@@ -59,6 +41,56 @@
                         <service.http.port>${service.http.port}</service.http.port>
                     </properties>
                 </configuration>
+            </plugin>
+
+            <plugin>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>start</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <property name="runtime_classpath" refid="maven.runtime.classpath"/>
+                                <java jar="../lra-coordinator/target/lra-coordinator-swarm.jar" spawn="true" fork="true">
+                                </java>
+                            </target>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>stop</id>
+                        <phase>post-integration-test</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <exec executable="${JAVA_HOME}/bin/jps">
+                                    <arg value="-l" />
+                                    <redirector outputproperty="process.pid">
+                                        <outputfilterchain>
+                                            <linecontains>
+                                                <contains value="lra-coordinator-swarm.jar" />
+                                            </linecontains>
+                                            <replaceregex pattern=" .*lra-coordinator-swarm.jar" replace="" flags="i"/>
+                                        </outputfilterchain>
+                                    </redirector>
+                                </exec>
+                                <exec executable="taskkill" osfamily="winnt">
+                                    <arg value="/PID" />
+                                    <arg value="${process.pid}" />
+                                </exec>
+                                <exec executable="kill" osfamily="unix">
+                                    <arg value="-15" />
+                                    <arg value="${process.pid}" />
+                                </exec>
+                            </target>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>
@@ -76,12 +108,23 @@
             <artifactId>lra-filters</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${version.jackson}</version>
+            <scope>provided</scope>
+        </dependency>
 
-        <!-- JAXRS 2 Client API implementation -->
+        <!-- Testing -->
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-client</artifactId>
             <version>${version.resteasy-client}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.swarm</groupId>
+            <artifactId>arquillian</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/rts/lra/lra-test/pom.xml
+++ b/rts/lra/lra-test/pom.xml
@@ -6,7 +6,7 @@
 
     <parent>
         <groupId>org.jboss.narayana.rts</groupId>
-        <artifactId>rest-lra-parent</artifactId>
+        <artifactId>lra-parent</artifactId>
         <version>5.6.0.Final-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>

--- a/rts/lra/lra-test/pom.xml
+++ b/rts/lra/lra-test/pom.xml
@@ -31,6 +31,13 @@
                 <groupId>org.wildfly.swarm</groupId>
                 <artifactId>wildfly-swarm-plugin</artifactId>
                 <version>${version.wildfly-swarm}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>package</goal>
+                        </goals>
+                    </execution>
+                </executions>
                 <configuration>
                     <environment>
                         <swarm.http.port>${swarm.http.port}</swarm.http.port>

--- a/rts/lra/lra-test/src/main/java/TripClient.java
+++ b/rts/lra/lra-test/src/main/java/TripClient.java
@@ -44,7 +44,7 @@ public class TripClient {
     ObjectMapper objectMapper = new ObjectMapper();
 
     private static void initClient() {
-        int servicePort = Integer.getInteger("sra.demo.service.http.port", 8081);
+        int servicePort = Integer.getInteger("lra.demo.service.http.port", 8081);
 
         PRIMARY_SERVER = "http://localhost:" + servicePort;
         TRIP_SERVICE_BASE_URL = String.format("%s%s", PRIMARY_SERVER, TripController.TRIP_PATH);

--- a/rts/lra/lra-test/src/main/java/participant/api/ActivityController.java
+++ b/rts/lra/lra-test/src/main/java/participant/api/ActivityController.java
@@ -198,7 +198,7 @@ public class ActivityController {
         if (lraId != null)
             throw new WebApplicationException(Response.Status.NOT_ACCEPTABLE);
 
-        // manually start an LRA via the injection LRAClient sra.demo.api
+        // manually start an LRA via the injection LRAClient lra.demo.api
         URL lra = lraClient.startLRA("subActivity", 0L);
 
         lraId = lra.toString();

--- a/rts/lra/lra-test/src/main/java/participant/api/ActivityController.java
+++ b/rts/lra/lra-test/src/main/java/participant/api/ActivityController.java
@@ -356,7 +356,7 @@ public class ActivityController {
         activityService.add(new Activity(LRAClient.getLRAId(lraId)));
 
         try {
-            Thread.sleep(200); // sleep for 200000 micro seconds (should be longer than specified in the @TimeLimit annotation)
+            Thread.sleep(200); // sleep for 200 miliseconds (should be longer than specified in the @TimeLimit annotation)
         } catch (InterruptedException e) {
             e.printStackTrace();
         }

--- a/rts/lra/lra-test/src/main/java/participant/demo/AsyncTripController.java
+++ b/rts/lra/lra-test/src/main/java/participant/demo/AsyncTripController.java
@@ -78,7 +78,7 @@ public class AsyncTripController {
     @PostConstruct
     private void initController() {
         try {
-            int servicePort = Integer.getInteger("sra.demo.service.http.port", 8081);
+            int servicePort = Integer.getInteger("lra.demo.service.http.port", 8081);
             URL HOTEL_SERVICE_BASE_URL = new URL("http://localhost:" + servicePort);
             URL FLIGHT_SERVICE_BASE_URL = new URL("http://localhost:" + servicePort);
 

--- a/rts/lra/lra-test/src/main/java/participant/demo/TripCheck.java
+++ b/rts/lra/lra-test/src/main/java/participant/demo/TripCheck.java
@@ -31,7 +31,7 @@ import java.util.Arrays;
 
 /**
  * For testing - verify that the business data returned when ending an LRA is the same as that returned by directly
- * interrogating each sra.demo.service involved in the booking
+ * interrogating each lra.demo.service involved in the booking
  */
 class TripCheck {
     static boolean validateBooking(Booking booking, WebTarget hotelTarget, WebTarget flightTarget) throws BookingException {

--- a/rts/lra/lra-test/src/main/java/participant/demo/TripController.java
+++ b/rts/lra/lra-test/src/main/java/participant/demo/TripController.java
@@ -75,7 +75,7 @@ public class TripController extends Compensator {
     @PostConstruct
     private void initController() {
         try {
-            int servicePort = Integer.getInteger("sra.demo.service.http.port", 8081);
+            int servicePort = Integer.getInteger("lra.demo.service.http.port", 8081);
             URL HOTEL_SERVICE_BASE_URL = new URL("http://localhost:" + servicePort);
             URL FLIGHT_SERVICE_BASE_URL = new URL("http://localhost:" + servicePort);
 

--- a/rts/lra/lra-test/src/test/java/participant/SpecIT.java
+++ b/rts/lra/lra-test/src/test/java/participant/SpecIT.java
@@ -48,6 +48,7 @@ import javax.ws.rs.core.Response;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.narayana.rts.lra.client.Current;
 import org.jboss.narayana.rts.lra.client.LRAClient;
 import org.jboss.narayana.rts.lra.client.LRAStatus;
 import org.jboss.shrinkwrap.api.Archive;
@@ -141,6 +142,7 @@ public class SpecIT {
                 }
             });
         }
+        Current.popAll();
     }
 
     // TODO add a test for a compensator annotated with @TimeLimit

--- a/rts/lra/lra-test/src/test/resources/arquillian-swarm.xml
+++ b/rts/lra/lra-test/src/test/resources/arquillian-swarm.xml
@@ -1,0 +1,16 @@
+<arquillian>
+
+  <extension qualifier="webdriver">
+    <property name="browser">phantomjs</property>
+  </extension>
+
+  <container qualifier="daemon" default="true">
+    <configuration>
+      <property name="host">localhost</property>
+      <property name="port">${swarm.arquillian.daemon.port:12345}</property>
+      <property name="javaVmArguments">-Dswarm.http.port=8081</property>
+    </configuration>
+  </container>
+
+</arquillian>
+

--- a/rts/lra/lra-test/src/test/resources/arquillian-swarm.xml
+++ b/rts/lra/lra-test/src/test/resources/arquillian-swarm.xml
@@ -8,7 +8,7 @@
     <configuration>
       <property name="host">localhost</property>
       <property name="port">${swarm.arquillian.daemon.port:12345}</property>
-      <property name="javaVmArguments">-Dswarm.http.port=8081</property>
+      <property name="javaVmArguments">-Dswarm.http.port=8081 ${swarm.debug.params} ${swarm.logging.params}</property>
     </configuration>
   </container>
 

--- a/rts/lra/pom.xml
+++ b/rts/lra/pom.xml
@@ -14,9 +14,9 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
-    <artifactId>rest-lra-parent</artifactId>
-    <name>REST-LRA: Parent</name>
-    <description>REST-LRA: Parent</description>
+    <artifactId>lra-parent</artifactId>
+    <name>LRA Parent</name>
+    <description>LRA Parent</description>
     <packaging>pom</packaging>
 
     <properties>

--- a/rts/lra/pom.xml
+++ b/rts/lra/pom.xml
@@ -20,41 +20,45 @@
     <packaging>pom</packaging>
 
     <properties>
-        <skipTests>true</skipTests>
-        <version.wildfly-swarm>2017.2.0</version.wildfly-swarm>
-        <!-- Impportant: the resteasy client version must match the one used by wildfly.swarm -->
-        <xversion.resteasy-client>3.0.14.Final</xversion.resteasy-client>
+        <version.wildfly-swarm>2017.8.1</version.wildfly-swarm>
         <version.resteasy-client>3.1.3.Final</version.resteasy-client>
         <version.json.api>1.1</version.json.api>
         <version.jaxrs.api>1.0.0.Final</version.jaxrs.api>
+        <version.jackson>2.8.9</version.jackson>
 
         <version.jboss-interceptors>1.0.1.Final</version.jboss-interceptors>
         <version.jaxrs-api>2.0</version.jaxrs-api>
-        <version.cdi-api>1.0-SP1</version.cdi-api>
+        <version.cdi-api>1.2</version.cdi-api>
         <version.junit>4.12</version.junit>
+        <version.arquillian>1.1.12.Final</version.arquillian>
 
         <version.narayana>${project.version}</version.narayana>
 
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+        <test.logs.to.file>false</test.logs.to.file>
     </properties>
 
-    <build>
-        <finalName>lra-test</finalName>
-        <plugins>
-            <plugin>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <!-- tests are run using the failsafe plugin -->
-                    <skip>${skipTests}</skip>
-                    <systemPropertyVariables>
-                        <arquillian.xml>arquillian-swarm.xml</arquillian.xml>
-                    </systemPropertyVariables>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.wildfly.swarm</groupId>
+                <artifactId>bom-all</artifactId>
+                <version>${version.wildfly-swarm}</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.arquillian</groupId>
+                <artifactId>arquillian-bom</artifactId>
+                <version>${version.arquillian}</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <!-- for Intellij -->

--- a/rts/lra/pom.xml
+++ b/rts/lra/pom.xml
@@ -68,7 +68,55 @@
             <version>1.0.3.Final</version>
             <scope>provided</scope>
         </dependency>
+        <!-- for testing -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>${version.junit}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.shrinkwrap</groupId>
+            <artifactId>shrinkwrap-impl-base</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.shrinkwrap.resolver</groupId>
+            <artifactId>shrinkwrap-resolver-impl-maven</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <configuration>
+                    <redirectTestOutputToFile>${test.logs.to.file}</redirectTestOutputToFile>
+                    <systemProperties>
+                        <arquillian.xml>arquillian-swarm.xml</arquillian.xml>
+                    </systemProperties>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <!-- Running only integration tests with failsafe plugin -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
     <modules>
         <module>lra-client</module>
@@ -76,5 +124,6 @@
         <module>lra-coordinator</module>
         <module>lra-filters</module>
         <module>lra-test</module>
+        <module>lra-cdi-rest</module>
     </modules>
 </project>


### PR DESCRIPTION
This PR adds a new module of CDI extension which does simple checking of correct usage of LRA annotation at the classes.
The second big change is restructuralization of dependencies and testcases for being able to run tests during `verify` goal.

The changes in details from top to bottom

* I think by general refactoring there were made a chane of 'lra' prefix for demo to 'sra'. I expect this is not correct and lra should be used.
* I renamed the parent maven module name to start with 'lra' prefix as other modules starts with lra
* I was working with warnings shown at the startup of the coordinator - namely with
```
WARN  [org.jboss.as.weld] (ServerService Thread Pool -- 12) WFLYWELD0052: Using deployment classloader to load proxy classes for module io.swagger:main. Package-private access will not work. To fix this the module should declare dependencies on [org.jboss.weld.core, org.jboss.weld.spi]
WARN  [org.jboss.as.weld] (ServerService Thread Pool -- 12) WFLYWELD0052: Using deployment classloader to load proxy classes for module com.fasterxml.jackson.jaxrs.jackson-jaxrs-json-provider:main. Package-private access will not work. To fix this the module should declare dependencies on [org.jboss.weld.core, org.jboss.weld.spi]
WARN  [org.jboss.resteasy.resteasy_jaxrs.i18n] (ServerService Thread Pool -- 12) RESTEASY002155: Provider class org.jboss.narayana.rts.lra.filter.ClientLRARequestFilter is already registered.  2nd registration is being ignored.
WARN  [org.jboss.resteasy.resteasy_jaxrs.i18n] (ServerService Thread Pool -- 12) RESTEASY002155: Provider class org.jboss.narayana.rts.lra.filter.ClientLRAResponseFilter is already registered.  2nd registration is being ignored.
```
Warning of proxy cdi loading is not possible to remove without changing `module.xml` of the particular swarm fraction (at least I haven't found other way) thus I'm leaving it as it is.
The warning with second registration is fixed by this commit as provider was registered by @Provider annotation and with the `javax.ws.rs.ext.Providers` descriptor. Leaving only the annotations.
* the other commit is big refactoring to get tests of `lra-test` module under this module and making the test to work.
* few small fixes + javadoc readability enhancements