### PR TITLE
[JBTM-1488] test fix

### DIFF
--- a/rts/lra/lra-cdi-rest/src/test/java/org/jboss/narayana/rts/lra/cdi/test/StartCdiCheckIT.java
+++ b/rts/lra/lra-cdi-rest/src/test/java/org/jboss/narayana/rts/lra/cdi/test/StartCdiCheckIT.java
@@ -108,7 +108,8 @@ public class StartCdiCheckIT {
 
     @Test
     public void allCorrect() throws Exception {
-        Swarm swarm = new Swarm()
+        File logFile = tmpFolder.newFile();
+        Swarm swarm = new Swarm(getLoggingArgs(logFile))
             .fraction(new JAXRSFraction())
             .fraction(new CDIFraction())
             .start();

--- a/rts/lra/lra-filters/src/main/java/org/jboss/narayana/rts/lra/filter/ServerLRAFilter.java
+++ b/rts/lra/lra-filters/src/main/java/org/jboss/narayana/rts/lra/filter/ServerLRAFilter.java
@@ -94,7 +94,7 @@ public class ServerLRAFilter implements ContainerRequestFilter, ContainerRespons
 
 //    // TODO figure out how to disable the filters for the coordinator (they remove the
 //    private boolean isCoordinator() {
-//        return resourceInfo.getResourceClass().getName().equals("org.jboss.narayana.rts.lra.coordinator.lra.demo.api.Coordinator")
+//        return resourceInfo.getResourceClass().getName().equals("org.jboss.narayana.rts.lra.coordinator.api.Coordinator")
 //    }
 
     @Override

--- a/rts/lra/lra-test/src/main/java/participant/api/ActivityController.java
+++ b/rts/lra/lra-test/src/main/java/participant/api/ActivityController.java
@@ -28,6 +28,7 @@ import org.jboss.narayana.rts.lra.annotation.Leave;
 import org.jboss.narayana.rts.lra.annotation.NestedLRA;
 import org.jboss.narayana.rts.lra.annotation.Status;
 import org.jboss.narayana.rts.lra.annotation.TimeLimit;
+import org.jboss.narayana.rts.lra.client.Current;
 import org.jboss.narayana.rts.lra.client.IllegalLRAStateException;
 import org.jboss.narayana.rts.lra.client.LRAClient;
 import org.jboss.narayana.rts.lra.client.LRAClientAPI;
@@ -233,8 +234,13 @@ public class ActivityController {
 
     private String restPutInvocation(String path, String bodyText) {
         String id = null;
-        Response response = ClientBuilder.newClient().target(context.getBaseUri())
-                .path("activities").path(path).request().put(Entity.text(bodyText));
+        Response response = ClientBuilder.newClient()
+            .target(context.getBaseUri())
+            .path("activities")
+            .path(path)
+            .request()
+            .header(LRAClient.LRA_HTTP_HEADER, Current.peek())
+            .put(Entity.text(bodyText));
 
         if (response.hasEntity())
             id = response.readEntity(String.class);


### PR DESCRIPTION
Test fix contains adding lra id for client invocation from inside of the container. I don't understand why or/and if it worked before. Unfortunatelly
Now I experience the client invocation being called in different thread and the outcoming LraFilter then can't find the `Current.peek()` as it's bound as `ThreadLocal`.