### PR TITLE
fix mvn dependency coordinations to run spec test it

### DIFF
--- a/rts/lra/lra-coordinator/pom.xml
+++ b/rts/lra/lra-coordinator/pom.xml
@@ -50,13 +50,6 @@
                     </properties>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-failsafe-plugin</artifactId>
-                <configuration>
-                    <skipITs>true</skipITs>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
 

--- a/rts/lra/lra-coordinator/src/test/java/io/narayana/lra/test/LRASmokeIT.java
+++ b/rts/lra/lra-coordinator/src/test/java/io/narayana/lra/test/LRASmokeIT.java
@@ -76,7 +76,7 @@ public class LRASmokeIT {
 
         File[] libs = Maven.resolver()
             .loadPomFromFile("pom.xml")
-            .resolve("io.narayana:lra-filters")
+            .resolve("org.jboss.narayana.rts:lra-filters")
             .withTransitivity().as(File.class); 
 
         deployment.addAsLibraries(libs);


### PR DESCRIPTION
making the PR once again as it seems it was somehow overwritten as it's not available in the https://github.com/jbosstm/narayana/pull/1209